### PR TITLE
 FEAT : ApiResponseDto 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+	implementation "io.jsonwebtoken:jjwt-api:0.11.5"
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/src/main/java/com/PuzzleU/Server/ServerApplication.java
+++ b/src/main/java/com/PuzzleU/Server/ServerApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/PuzzleU/Server/common/ApiResponseDto.java
+++ b/src/main/java/com/PuzzleU/Server/common/ApiResponseDto.java
@@ -1,0 +1,21 @@
+package com.PuzzleU.Server.common;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.ErrorResponse;
+
+@Getter
+public class ApiResponseDto<T> {
+
+    private boolean success;
+    private T response;
+    private ErrorResponse error;
+
+    @Builder
+    ApiResponseDto(boolean success, T response, ErrorResponse error)
+    {
+        this.success = success;
+        this.response = response;
+        this.error = error;
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/common/ErrorResponse.java
+++ b/src/main/java/com/PuzzleU/Server/common/ErrorResponse.java
@@ -1,0 +1,48 @@
+package com.PuzzleU.Server.common;
+
+import com.PuzzleU.Server.entity.enumSet.ErrorType;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+public class ErrorResponse {
+    private int status;
+    private String message;
+
+    @Builder
+    private ErrorResponse(int status, String message)
+    {
+        this.status = status;
+        this.message = message;
+    }
+
+    // 에러 타입에 대해서 에러 타입에서 어떤 코드고 어떤 메시지를 담는지 각각 가져와서 넣어주고 생성
+    public static ErrorResponse of(ErrorType errorType)
+    {
+        return ErrorResponse.builder()
+                .status(errorType.getCode())
+                .message(errorType.getMessage())
+                .build();
+    }
+    // http 상 에러가 생길 때 http에러와 메시지를 담아서 errorresponse 생성
+    public static ErrorResponse of(HttpStatus status, String message)
+    {
+        return ErrorResponse.builder()
+                .status(status.value())
+                .message(message)
+                .build();
+    }
+    // BindingResult(Spring MVC에서 양식 제출의 바인딩 결과를 나타내고 데이터 유효성 검사를 수행)
+    public static ErrorResponse of(BindingResult bindingResult) {
+        String message = "";
+        // 유효성 검사를 한다
+        if (bindingResult.hasErrors()) {
+            // 첫 번째 오류의 기본 오류 메시지를 가져온다
+            message = bindingResult.getAllErrors().get(0).getDefaultMessage();
+        }
+        // HttpStatus.BAD_REQUEST 상태와 오류 메시지로 ErrorResponse 객체를 생성하고 반환
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, message);
+    }
+
+
+}

--- a/src/main/java/com/PuzzleU/Server/common/ResponseUtils.java
+++ b/src/main/java/com/PuzzleU/Server/common/ResponseUtils.java
@@ -1,0 +1,23 @@
+package com.PuzzleU.Server.common;
+
+import org.springframework.web.ErrorResponse;
+
+public class ResponseUtils {
+
+    // 요청 성공인 경우
+    public static <T> ApiResponseDto<T> ok(T response)
+    {
+        return ApiResponseDto.<T>builder()
+                .success(true)
+                .response(response)
+                .build();
+    }
+    // 에러가 발생한 경우
+    public static <T> ApiResponseDto<T> error(ErrorResponse response)
+    {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .error(response) // 이 에러 리스폰스에는 status와 message가 담겨있다
+                .build();
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/common/SuccessResponse.java
+++ b/src/main/java/com/PuzzleU/Server/common/SuccessResponse.java
@@ -1,0 +1,25 @@
+package com.PuzzleU.Server.common;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class SuccessResponse {
+    private int status;
+    private String message;
+
+    @Builder
+    private SuccessResponse(int status, String message)
+    {
+        this.status = status;
+        this.message = message;
+    }
+    public static SuccessResponse of(HttpStatus status, String message)
+    {
+        return SuccessResponse.builder()
+                .status(status.value())
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/config/JpaAuditingConfig.java
+++ b/src/main/java/com/PuzzleU/Server/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package com.PuzzleU.Server.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaAuditingConfig {
-}

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
@@ -1,0 +1,23 @@
+package com.PuzzleU.Server.entity.enumSet;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorType {
+    NOT_VALID_TOKEN(400, "토큰이 유효하지 않습니다."),
+    NOT_WRITER(400, "작성자만 삭제/수정할 수 있습니다."),
+    DUPLICATED_USERNAME(400, "중복된 username 입니다."),
+    NOT_MATCHING_INFO(400, "회원을 찾을 수 없습니다."),
+    NOT_MATCHING_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
+    NOT_FOUND_USER(400, "사용자가 존재하지 않습니다."),
+    NOT_FOUND_WRITING(400, "게시글/댓글이 존재하지 않습니다.");
+
+    private int code;
+    private String message;
+
+    //  Error Type 생성자 생성
+    ErrorType(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,15 @@
+jwts.secretkey = sfeffewgewrwqre21321321321ed2ed21e21qd
+
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.username=root
+spring.datasource.password=Ab016018!@
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.h2.console.enabled=true
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+
+logging.level.org.hibernate.SQL=debug
+logging.level.org.hibernate.type.descriptor.sql =trace
 


### PR DESCRIPTION
- API 연결시
- 성공했는지의 SUCCESS
- 어떤 응답이였는지의 RESPONSE
- 에러가 났다면 어떤 에러인지의 ERROR를 
- 생성해주는 Dto ApiResponseDto를 추가

- T 타입에 따라 성공인지 아닌지에 따른 ApiResponseDto를 생성해주는 ResponseUtils 추가
- 에러에 errorType에 해당하는 status와 그에 해당하는 메시지를 담는 객체를 생성해주는 ErrorResponse 추가
- 성공했을 때 status와 그에 해당하는 메시지를 담는 객체를 생성해주는 SccuesResponse 추가

#요약
0, ApiResponseDto는 데이터 전달 Tool
1. Error type과 메시지를 담은 ErrorResponse를 통해 ResponseUtils를 통해 실패 전달
or
2. SuccessResponse를 통해 ResponseUtils로 성공 전달