### PR TITLE
[FIX] Modify User nullable setting

### DIFF
--- a/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
@@ -52,7 +52,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests((authorizeRequests)->
                         authorizeRequests
                                 .requestMatchers("/api/user/**").permitAll()
-                                .requestMatchers("/api/oauth/***").permitAll()
+                                .requestMatchers("/api/oauth/**").permitAll()
                                 .requestMatchers(HttpMethod.GET,"/api/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/post/{id}").permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/PuzzleU/Server/controller/OAuthController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/OAuthController.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.controller;
 
 import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.SuccessResponse;
+import com.PuzzleU.Server.dto.KakaoUserInfoDto;
 import com.PuzzleU.Server.service.Impl.OAuthService;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/PuzzleU/Server/entity/user/User.java
+++ b/src/main/java/com/PuzzleU/Server/entity/user/User.java
@@ -38,16 +38,18 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
 
-    @Column(nullable = false, length = 20)
+    // 필수 정보
+    @Column(nullable = true, length = 20)
     private String userPuzzleId;
 
-    @Column(nullable = false, length = 6)
+    @Column(nullable = true, length = 6)
     private String userKoreaName;
 
     @OneToOne
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = true)
     private Profile userProfile;
 
+    // 선택 정보
     @Column(nullable = true)
     @Enumerated(value = EnumType.STRING)
     private UniversityStatus universityStatus;


### PR DESCRIPTION
카카오/애플 로그인으로 유저 테이블을 우선 만든 후, 필수 정보들을 입력하는 로직이기 때문에 회원가입 필수 입력 요소들을 nullable=true로 변경했습니다.