### PR TITLE
[FIX] 연관 관계 수정 & Cascade Type 수정 & splash page 예외 처리 적용

### DIFF
--- a/src/main/java/com/PuzzleU/Server/entity/apply/Apply.java
+++ b/src/main/java/com/PuzzleU/Server/entity/apply/Apply.java
@@ -2,6 +2,8 @@ package com.PuzzleU.Server.entity.apply;
 
 import com.PuzzleU.Server.entity.BaseEntity;
 import com.PuzzleU.Server.entity.enumSet.ApplyStatus;
+import com.PuzzleU.Server.entity.team.Team;
+import com.PuzzleU.Server.entity.university.University;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +16,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Apply extends BaseEntity {
+public class Apply {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long applyId;
@@ -25,7 +27,12 @@ public class Apply extends BaseEntity {
     @Column(length = 500)
     private String applyContent; // 지원서 내용
 
-    @ColumnDefault("WAITING")
+    @ColumnDefault("'WAITING'") // 따옴표 써야 SQL에서 인식함
     @Enumerated(value = EnumType.STRING)
     private ApplyStatus applyStatus; // 지원 상태 (대기/완료/취소)
+
+    // 의존 관계 매핑 (Team)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
 }

--- a/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
+++ b/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
@@ -73,7 +73,7 @@ public class Competition extends BaseEntity {
     @OneToMany(mappedBy = "competition",cascade = CascadeType.ALL)
     private List<Heart> heart = new ArrayList<>();
 
-    @OneToMany(mappedBy = "competition", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "competition", cascade = CascadeType.REMOVE)
     private List<CompetitionInterestRelation> competitionInterestRelations = new ArrayList<>();
 
 }

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/ApplyStatus.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/ApplyStatus.java
@@ -1,5 +1,5 @@
 package com.PuzzleU.Server.entity.enumSet;
 
 public enum ApplyStatus {
-    WAITING, FINISHED,  CANCEL // 대기, 완료, 취소
+    WAITING, FINISHED, CANCEL // 대기, 완료, 취소
 }

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
@@ -16,7 +16,11 @@ public enum ErrorType {
     NOT_FOUND_MAJOR(400, "전공이 존재하지 않습니다"),
     NOT_FOUND_EXPERIENCE(400, "경험이 존재하지 않습니다"),
     NOT_FOUND_UNIVERSITY(400, "대학이 존재하지 않습니다"),
-    NOT_FOUND_USERSKILLSETRELATION(400, "유저와 스킬셋의 관계가 존재하지 않습니다");
+    NOT_FOUND_USERSKILLSETRELATION(400, "유저와 스킬셋의 관계가 존재하지 않습니다"),
+    NOT_FOUND_POSITION_LIST(404, "포지션 리스트가 존재하지 않습니다."),
+    NOT_FOUND_INTEREST_LIST(404, "관심 분야 리스트가 존재하지 않습니다."),
+    NOT_FOUND_LOCATION_LIST(404, "지역 리스트가 존재하지 않습니다."),
+    NOT_FOUND_PROFILE_LIST(404, "프로필 리스트가 존재하지 않습니다.");
 
     private int code;
     private String message;

--- a/src/main/java/com/PuzzleU/Server/entity/interest/Interest.java
+++ b/src/main/java/com/PuzzleU/Server/entity/interest/Interest.java
@@ -30,9 +30,9 @@ public class Interest {
     @Enumerated(value = EnumType.STRING)
     private InterestTypes interestType;
 
-    @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "interest", cascade = CascadeType.REMOVE)
     private List<UserInterestRelation> userInterestRelation = new ArrayList<>();
 
-    @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "interest", cascade = CascadeType.REMOVE)
     private List<CompetitionInterestRelation> competitionInterestRelations = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/entity/location/Location.java
+++ b/src/main/java/com/PuzzleU/Server/entity/location/Location.java
@@ -24,7 +24,7 @@ public class Location {
     @Column(name = "location_name")
     private String locationName;
 
-    @OneToMany(mappedBy = "location",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "location",cascade = CascadeType.REMOVE)
     private List<UserLocationRelation> userLocationRelation = new ArrayList<>();
 
 }

--- a/src/main/java/com/PuzzleU/Server/entity/position/Position.java
+++ b/src/main/java/com/PuzzleU/Server/entity/position/Position.java
@@ -24,6 +24,6 @@ public class Position {
     @Column(name = "position_name", length = 10)
     private String positionName; // 포지션 이름
 
-    @OneToMany(mappedBy = "position",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "position",cascade = CascadeType.REMOVE)
     private List<UserPositionRelation> userPositionRelation = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/entity/skillset/Skillset.java
+++ b/src/main/java/com/PuzzleU/Server/entity/skillset/Skillset.java
@@ -27,7 +27,7 @@ public class Skillset {
     @Column(length = 200)
     private String skillsetLogo;
 
-    @OneToMany(mappedBy = "skillset",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "skillset",cascade = CascadeType.REMOVE)
     private List<UserSkillsetRelation> userSkillsetRelation = new ArrayList<>();
     //
     //wqfqwfqw

--- a/src/main/java/com/PuzzleU/Server/entity/team/Team.java
+++ b/src/main/java/com/PuzzleU/Server/entity/team/Team.java
@@ -1,11 +1,16 @@
 package com.PuzzleU.Server.entity.team;
 
 import com.PuzzleU.Server.entity.BaseEntity;
+import com.PuzzleU.Server.entity.apply.Apply;
 import com.PuzzleU.Server.entity.competition.Competition;
+import com.PuzzleU.Server.entity.relations.UserPositionRelation;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DialectOverride;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "team")
@@ -47,5 +52,8 @@ public class Team extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id")
     private Competition competition;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
+    private List<Apply> applyList = new ArrayList<>();
 
 }

--- a/src/main/java/com/PuzzleU/Server/entity/user/User.java
+++ b/src/main/java/com/PuzzleU/Server/entity/user/User.java
@@ -81,25 +81,25 @@ public class User {
     @JoinColumn(name ="major_id")
     private Major major;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<UserInterestRelation> userInterestRelations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserLocationRelation> userLocationRelations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserPositionRelation> userPositionRelations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserSkillsetRelation> userSkillsetRelations = new ArrayList<>();
 
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
     private List<Experience> experience = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user1",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user1",cascade = CascadeType.REMOVE)
     private List<FriendShip> friendShip1 = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user2",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user2",cascade = CascadeType.REMOVE)
     private List<FriendShip> friendShip2 = new ArrayList<>();
 
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)

--- a/src/main/java/com/PuzzleU/Server/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/PuzzleU/Server/exception/CustomExceptionHandler.java
@@ -29,6 +29,6 @@ public class CustomExceptionHandler {
     {
         ErrorResponse response = ErrorResponse.of(e.getErrorType());
         log.error(response.getMessage());
-        return ResponseEntity.badRequest().body(ResponseUtils.error(response));
+        return ResponseEntity.status(response.getStatus()).body(ResponseUtils.error(response));
     }
 }

--- a/src/main/java/com/PuzzleU/Server/service/staticData/StaticDataService.java
+++ b/src/main/java/com/PuzzleU/Server/service/staticData/StaticDataService.java
@@ -1,15 +1,24 @@
 package com.PuzzleU.Server.service.staticData;
 
 import com.PuzzleU.Server.common.ApiResponseDto;
+import com.PuzzleU.Server.common.ErrorResponse;
 import com.PuzzleU.Server.common.ResponseUtils;
+import com.PuzzleU.Server.dto.interest.InterestDto;
+import com.PuzzleU.Server.dto.interest.InterestTypeDto;
+import com.PuzzleU.Server.dto.location.LocationDto;
+import com.PuzzleU.Server.dto.position.PositionDto;
+import com.PuzzleU.Server.dto.profile.ProfileDto;
 import com.PuzzleU.Server.dto.staticData.StaticDataDto;
-import com.PuzzleU.Server.repository.PositionRepository;
+import com.PuzzleU.Server.entity.enumSet.ErrorType;
+import com.PuzzleU.Server.exception.RestApiException;
 import com.PuzzleU.Server.service.LocationService;
 import com.PuzzleU.Server.service.interest.InterestService;
 import com.PuzzleU.Server.service.position.PositionService;
 import com.PuzzleU.Server.service.profile.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,11 +30,32 @@ public class StaticDataService {
 
     // 전체 static data 반환
     public ApiResponseDto<StaticDataDto> getAllStaticData() {
+
+        List<PositionDto> positionList = positionService.listAllPositions();
+        if (positionList.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_POSITION_LIST);
+        }
+
+        List<InterestTypeDto> interestList = interestService.listAllInterest();
+        if (interestList.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_INTEREST_LIST);
+        }
+
+        List<LocationDto> locationList = locationService.listAllLocations();
+        if (locationList.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_LOCATION_LIST);
+        }
+
+        List<ProfileDto> profileList = profileService.listAllProfiles();
+        if (profileList.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_PROFILE_LIST);
+        }
+
         StaticDataDto staticDataDto = StaticDataDto.builder()
-                .postionList(positionService.listAllPositions())
-                .interestList(interestService.listAllInterest())
-                .locationList(locationService.listAllLocations())
-                .profileList(profileService.listAllProfiles()).build();
+                .postionList(positionList)
+                .interestList(interestList)
+                .locationList(locationList)
+                .profileList(profileList).build();
 
         return ResponseUtils.ok(staticDataDto, null);
     }


### PR DESCRIPTION
### 1. apply와 team과의 연관관계 매핑
### 2. apply table 생성 안됨 해결
apply table이 생성 안됨 -> 엔티티에서 Column default 설정할 때 안에 작은 따옴표 추가해줘서 해결 ---`@ColumnDefault("'WAITING'")`
### 3. cascade type 수정
reltaion table에 대한 OneToMany 연관관계를 모두 cascadeType.REMOVE로 변경 (안 그러면 연결된 부모 엔티티가 삭제돼도 다른 부모 엔티티에 PERSIST 설정이 돼 있어서 자식 엔티티 삭제가 안됨)
### 4. splash page 예외 처리
-> customerExceptionHandler에서 모든 RestApiException이 400에러로 뜨게 설정되어 있어서 이걸 설정한 status 번호에 맞게 뜨도록 수정
