### PR TITLE
[FEAT] #63 Competition Homepage GET

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.modelmapper:modelmapper:2.4.4'
 	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
 	implementation'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/PuzzleU/Server/ServerApplication.java
+++ b/src/main/java/com/PuzzleU/Server/ServerApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.PageableDefault;
 
 @EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
+
 public class ServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);

--- a/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
@@ -52,6 +52,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests((authorizeRequests)->
                         authorizeRequests
                                 .requestMatchers("/api/user/**").permitAll()
+                                .requestMatchers("/api/competition/**").permitAll()
                                 .requestMatchers("/api/oauth/**").permitAll()
                                 .requestMatchers(HttpMethod.GET,"/api/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/post/{id}").permitAll()

--- a/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
@@ -1,0 +1,34 @@
+package com.PuzzleU.Server.controller;
+
+import com.PuzzleU.Server.common.ApiResponseDto;
+import com.PuzzleU.Server.common.SuccessResponse;
+import com.PuzzleU.Server.dto.competition.CompetitionDto;
+import com.PuzzleU.Server.dto.competition.CompetitionHomeTotalDto;
+import com.PuzzleU.Server.dto.user.SignupRequestDto;
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import com.PuzzleU.Server.service.competition.CompetitionService;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/competition")
+public class CompetitionController {
+
+    private final CompetitionService competitionService;
+
+    @GetMapping("/homepage")
+    public ApiResponseDto<CompetitionHomeTotalDto> homepage(
+            @RequestParam(value = "competitionType", required = false) CompetitionType competitionType,
+            @RequestParam(value = "search", defaultValue = "None", required = false) String search,
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy
+    ) {
+        return competitionService.getHomepage(pageNo, pageSize, sortBy, search, competitionType);
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -52,48 +52,48 @@ public class UserController {
     }
 
     @PatchMapping("/optional/{userId}")
-    public ApiResponseDto<SuccessResponse> registerOptional(
+    public ApiResponseDto<SuccessResponse> registerOptional(@Valid
             @RequestBody UserRegisterOptionalDto userRegisterOptionalDto,
             @PathVariable Long userId)
     {
         return userService.createRegisterOptionalUser(userId,userRegisterOptionalDto);
     }
     @PostMapping("/experience/{userId}")
-    public ApiResponseDto<SuccessResponse> postExperience(
+    public ApiResponseDto<SuccessResponse> postExperience(@Valid
             @RequestBody ExperienceDto experienceDto,
             @PathVariable Long userId)
     {
         return experienceService.createExperience(userId,experienceDto);
     }
     @PatchMapping("/experience/{userId}/{experienceId}")
-    public ApiResponseDto<SuccessResponse> updateExperience(
+    public ApiResponseDto<SuccessResponse> updateExperience(@Valid
             @RequestBody ExperienceDto experienceDto,
             @PathVariable Long userId, @PathVariable Long experienceId)
     {
         return experienceService.updateExperience(userId, experienceId,experienceDto);
     }
     @DeleteMapping("/experience/{userId}/{experienceId}")
-    public ApiResponseDto<SuccessResponse> deleteExperience(
+    public ApiResponseDto<SuccessResponse> deleteExperience(@Valid
             @PathVariable Long userId, @PathVariable Long experienceId)
     {
         return experienceService.deleteExperience(userId, experienceId);
     }
     @GetMapping("/experience/{userId}")
-    public ApiResponseDto<List<ExperienceDto>> getExperienceList(
+    public ApiResponseDto<List<ExperienceDto>> getExperienceList(@Valid
             @PathVariable Long userId
     )
     {
         return experienceService.getExperienceList(userId);
     }
     @GetMapping("/experience/{userId}/{experienceId}")
-    public ApiResponseDto<ExperienceDto> getExperience(
+    public ApiResponseDto<ExperienceDto> getExperience(@Valid
             @PathVariable Long userId, @PathVariable Long experienceId
     )
     {
         return experienceService.getExperience(userId,experienceId);
     }
     @PostMapping("/skillset/{userId}")
-    public ApiResponseDto<SuccessResponse> createSkillset(
+    public ApiResponseDto<SuccessResponse> createSkillset(@Valid
             @PathVariable Long userId,
             @RequestBody SkillSetListDto skillsetList
     )
@@ -101,7 +101,7 @@ public class UserController {
         return skillsetService.createSkillset(userId, skillsetList);
     }
     @DeleteMapping("/skillset/{userId}/{skillsetId}")
-    public ApiResponseDto<SuccessResponse> deleteSkillset(
+    public ApiResponseDto<SuccessResponse> deleteSkillset(@Valid
             @PathVariable Long userId,
             @PathVariable Long skillsetId
     )
@@ -109,14 +109,14 @@ public class UserController {
         return skillsetService.deleteSkillset(userId, skillsetId);
     }
     @GetMapping("/skillset/{userId}")
-    public ApiResponseDto<List<UserSkillsetRelationDto>> getUserSkillsetList(
+    public ApiResponseDto<List<UserSkillsetRelationDto>> getUserSkillsetList(@Valid
             @PathVariable Long userId
     )
     {
         return skillsetService.getSkillsetList(userId);
     }
     @PatchMapping("/university/{userId}")
-    public ApiResponseDto<SuccessResponse> createUniversity(
+    public ApiResponseDto<SuccessResponse> createUniversity(@Valid
             @PathVariable Long userId,
             @RequestBody UserUniversityDto userUniversityDto
             )

--- a/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionDto.java
@@ -1,0 +1,38 @@
+package com.PuzzleU.Server.dto.competition;
+
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import jakarta.persistence.Temporal;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompetitionDto {
+
+    @Size(max = 100)
+    private String competitionName;
+    @Size(max = 200)
+    private String competitionUrl;
+    @Size(max = 50)
+    private String CompetitionHost;
+    @Size(max = 200)
+    private String CompetitionPoster;
+    @Size(max = 50)
+    private String CompetitionAwards;
+
+    private Date CompetitionStart;
+    private Date CompetitionEnd;
+    private Date CompetitionContent;
+    private Integer CompetitionVisit;
+    private Integer CompetitionLike;
+    private Integer CompetitionMatching;
+    private Date CompetitionUpload;
+    private Integer competitionDday;
+    private List<CompetitionType> competitionTypeList;
+}

--- a/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionHomePageDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionHomePageDto.java
@@ -1,0 +1,26 @@
+package com.PuzzleU.Server.dto.competition;
+
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompetitionHomePageDto {
+    @Size(max = 100)
+    private String competitionName;
+    private Integer CompetitionVisit;
+    private Integer CompetitionMatching;
+    private List<CompetitionType> competitionTypeList;
+    private Integer CompetitionDday;
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionHomeTotalDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionHomeTotalDto.java
@@ -1,0 +1,19 @@
+package com.PuzzleU.Server.dto.competition;
+
+import lombok.*;
+
+import java.util.List;
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompetitionHomeTotalDto {
+    private List<CompetitionHomePageDto> competitionList;
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+}

--- a/src/main/java/com/PuzzleU/Server/dto/experience/ExperienceDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/experience/ExperienceDto.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.dto.experience;
 
 import com.PuzzleU.Server.entity.enumSet.ExperienceType;
 import com.PuzzleU.Server.entity.experience.Experience;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -14,6 +15,7 @@ public class ExperienceDto {
 
     private Long ExperienceId;
 
+    @Size(max = 100)
     private String ExperienceName;
 
     private ExperienceType ExperienceType;

--- a/src/main/java/com/PuzzleU/Server/dto/university/UniversityDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/university/UniversityDto.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.dto.university;
 import com.PuzzleU.Server.dto.major.MajorDto;
 import com.PuzzleU.Server.entity.enumSet.UniversityType;
 import com.PuzzleU.Server.entity.major.Major;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -13,6 +14,7 @@ import lombok.*;
 @Builder
 public class UniversityDto {
     private Long UniversityId;
+    @Size(max = 15)
     private UniversityType universityType;
     private String universityName;
 }

--- a/src/main/java/com/PuzzleU/Server/dto/user/UserRegisterOptionalDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/user/UserRegisterOptionalDto.java
@@ -4,6 +4,7 @@ import com.PuzzleU.Server.dto.experience.ExperienceDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetDto;
 import com.PuzzleU.Server.entity.enumSet.UniversityStatus;
 import com.PuzzleU.Server.entity.enumSet.WorkType;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.List;
@@ -26,9 +27,9 @@ public class UserRegisterOptionalDto {
     private Long UniversityId;
 
     private Long MajorId;
-
+    @Size(max=100)
     private String UserRepresentativeExperience;
-
+    @Size(max=100)
     private String UserRepresentativeProfileSentence;
 
     private WorkType UserWorkType;

--- a/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
+++ b/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.entity.competition;
 
 import com.PuzzleU.Server.entity.BaseEntity;
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
 import com.PuzzleU.Server.entity.heart.Heart;
 import com.PuzzleU.Server.entity.interest.Interest;
 import com.PuzzleU.Server.entity.relations.CompetitionInterestRelation;
@@ -10,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.util.ArrayList;
@@ -66,6 +68,12 @@ public class Competition extends BaseEntity {
     @Column(name = "competition_d_day", nullable = true)
     private Integer competitionDDay;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "competition_types", joinColumns = @JoinColumn(name = "competition_id"))
+    @Column(name = "competition_type")
+    private List<CompetitionType> competitionTypes;
+
 
     @OneToMany(mappedBy = "competition",cascade = CascadeType.ALL)
     private List<Team> team = new ArrayList<>();
@@ -76,6 +84,5 @@ public class Competition extends BaseEntity {
     @OneToMany(mappedBy = "competition", cascade = CascadeType.ALL)
     private List<CompetitionInterestRelation> competitionInterestRelations = new ArrayList<>();
 
-    private Integer competitionDday;
 
 }

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/CompetitionType.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/CompetitionType.java
@@ -1,0 +1,22 @@
+package com.PuzzleU.Server.entity.enumSet;
+
+import lombok.Getter;
+
+@Getter
+public enum CompetitionType {
+    PLAN("기획"),
+    DESIGN("디자인"),
+    LITURE("문학"),
+    MEDIA("미디어"),
+    MARKET("마케팅"),
+    NAME("네이밍"),
+    ART("예술"),
+    IT("IT"),
+    START("창업"),
+    ETC("기타");
+    private final String message;
+
+    CompetitionType(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
@@ -1,9 +1,38 @@
 package com.PuzzleU.Server.repository;
 
 import com.PuzzleU.Server.entity.competition.Competition;
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import feign.Param;
+import io.micrometer.common.lang.NonNullApi;
+import lombok.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
+@NonNullApi
 public interface CompetitionRepository extends JpaRepository<Competition, Long> {
+    Page<Competition> findAll(@NonNull Pageable pageable);
+    Page<Competition> findByCompetitionNameContaining(Pageable pageable,String keyword);
+
+
+    @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE c.competitionId = :id")
+    Optional<Competition> findByCompetitionIdWithCompetitionTypes(@Param("id") Long id);
+
+    @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE c.competitionName LIKE %:keyword% AND :type MEMBER OF c.competitionTypes")
+    List<Competition> findByKeywordAndType(@Param("keyword") String keyword, @Param("type") CompetitionType type);
+
+    @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE :type MEMBER OF c.competitionTypes")
+    List<Competition> findByType(@Param("type") CompetitionType type, Pageable pageable);
+
+    @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE c.competitionName LIKE %:keyword%")
+    List<Competition> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
 }
+

--- a/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
@@ -1,0 +1,89 @@
+package com.PuzzleU.Server.service.competition;
+
+import com.PuzzleU.Server.common.ApiResponseDto;
+import com.PuzzleU.Server.common.ResponseUtils;
+import com.PuzzleU.Server.dto.competition.CompetitionDto;
+import com.PuzzleU.Server.dto.competition.CompetitionHomePageDto;
+import com.PuzzleU.Server.dto.competition.CompetitionHomeTotalDto;
+import com.PuzzleU.Server.entity.competition.Competition;
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import com.PuzzleU.Server.repository.CompetitionRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CompetitionService {
+
+    private final CompetitionRepository competitionRepository;
+
+    private final Logger logger = LoggerFactory.getLogger(CompetitionService.class);
+
+    @Transactional
+    public ApiResponseDto<CompetitionHomeTotalDto> getHomepage(int pageNo, int pageSize, String sortBy, String keyword, CompetitionType type) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
+        Page<Competition> competitionPage;
+        String None = "None";
+        // 키워드와 타입이 모두 제공
+        // 안됨
+        if (!keyword.equals(None) && type != null) {
+            System.out.println("1");
+            competitionPage = new PageImpl<>(competitionRepository.findByKeywordAndType(keyword, type));
+        }
+        // 키워드는 없고 타입만 제공될 때
+        //안됨
+        else if (keyword.equals(None) && type !=null) {
+            System.out.println("2");
+            competitionPage = new PageImpl<>(competitionRepository.findByType(type, pageable));
+        }
+        // 키워드만 존재할 때
+        // 잘됨
+        else if (!keyword.equals(None) && type == null) {
+            System.out.println("3");
+            competitionPage = new PageImpl<>(competitionRepository.findByKeyword(keyword, pageable));
+        }
+        // 키워드와 타입 둘 다 없을 때
+        // 잘됨
+        else {
+            System.out.println("4");
+            competitionPage = competitionRepository.findAll(pageable);
+        }
+
+        List<CompetitionHomePageDto> competitionHomePageDtos = competitionPage.getContent().stream()
+                .map(competition -> {
+                    CompetitionHomePageDto competitionHomePageDto = new CompetitionHomePageDto();
+                    competitionHomePageDto.setCompetitionDday(competition.getCompetitionDDay());
+                    competitionHomePageDto.setCompetitionName(competition.getCompetitionName());
+                    competitionHomePageDto.setCompetitionMatching(competition.getCompetitionMatching());
+                    competitionHomePageDto.setCompetitionVisit(competition.getCompetitionVisit());
+                    competitionHomePageDto.setCreatedAt(competition.getCreatedDate());
+                    competitionHomePageDto.setCompetitionTypeList(competition.getCompetitionTypes());
+                    return competitionHomePageDto;
+                })
+                .collect(Collectors.toList());
+
+        CompetitionHomeTotalDto competitionHomeTotalDto = new CompetitionHomeTotalDto();
+        competitionHomeTotalDto.setCompetitionList(competitionHomePageDtos);
+        competitionHomeTotalDto.setPageNo(pageNo);
+        competitionHomeTotalDto.setPageSize(pageSize);
+        competitionHomeTotalDto.setTotalElements(competitionPage.getTotalElements());
+        competitionHomeTotalDto.setTotalPages(competitionPage.getTotalPages());
+        competitionHomeTotalDto.setLast(competitionPage.isLast());
+
+        return ResponseUtils.ok(competitionHomeTotalDto, null);
+    }
+
+
+
+}


### PR DESCRIPTION
## 공모전(Competition)을 볼 수 있는 (데이터를 받아올 수 있는) 코드를 구현하였습니다.
### pagination은 
pageNo(페이지 넘버),
pageSize(총 사이즈-한페이지당 볼 수 있는 공모전 수)
totalElements(총 요소(공모전) 수)
totalPages(총 페이지 수)
last(마지막페이지 유무)
를 볼 수 있도록 기존의 데이터 형식에 추가하였습니다.
### Competition 관련 
CompetitionName, 
CompetitionTypeList,
createAt, 
CompetitionDday, 
CompetitionMatching, 
CompetitionVisit에 대해서 설정을 해주었습니다
### Repository 변경
CompetitionRepository에서는 직접 jquery문을 작성한 repository를 작성하였습니다.

### Enum 관계 변경
Enum을 리스트로 처리하여 역직렬화 하는 과정에서 에러가 나서
Enum리스트를 가지는 CompetitionType을 연결된 추가적인 Table로 빼서 사용을 하였습니다.
getCompetitionType를 사용시 바로 가져올 수 있습니다.