### PR TITLE
[FEAT] #64 Competition Specific

### DIFF
--- a/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
@@ -4,6 +4,7 @@ import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.competition.CompetitionDto;
 import com.PuzzleU.Server.dto.competition.CompetitionHomeTotalDto;
+import com.PuzzleU.Server.dto.competition.CompetitionSpecificDto;
 import com.PuzzleU.Server.dto.user.SignupRequestDto;
 import com.PuzzleU.Server.entity.enumSet.CompetitionType;
 import com.PuzzleU.Server.service.competition.CompetitionService;
@@ -31,4 +32,11 @@ public class CompetitionController {
     ) {
         return competitionService.getHomepage(pageNo, pageSize, sortBy, search, competitionType);
     }
+    @GetMapping("/homepage/{competition_id}")
+    public ApiResponseDto<CompetitionSpecificDto> specific(@Valid
+            @PathVariable Long competition_id)
+    {
+        return competitionService.getSpecific(competition_id);
+    }
+
 }

--- a/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionSpecificDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionSpecificDto.java
@@ -1,0 +1,53 @@
+package com.PuzzleU.Server.dto.competition;
+
+import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import com.nimbusds.oauth2.sdk.util.date.SimpleDate;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompetitionSpecificDto {
+
+    private Long competitionId;
+    @Size(max = 100)
+    private String competitionName;
+    @Size(max =200)
+    private String competitionUrl;
+    @Size(max = 50)
+    private String competitionHost;
+    @Size(max = 200)
+    private String competitionPoster;
+    @Size(max =50)
+    private String competitionAwards;
+
+    private String competitionStart;
+    private String competitionEnd;
+    @Size(max = 2000)
+    private String competitionContent;
+    private Integer competitionVisit;
+    private Integer competitionLike;
+    private Integer competitionMatching;
+    private Integer competitionDDay;
+    private List<CompetitionType> competitionTypes;
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
+++ b/src/main/java/com/PuzzleU/Server/entity/competition/Competition.java
@@ -14,6 +14,8 @@ import lombok.Setter;
 import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -47,11 +49,11 @@ public class Competition extends BaseEntity {
 
     @Column(name = "competition_start", nullable = true)
     @Temporal(value = TemporalType.TIMESTAMP)
-    private Date competitionStart;
+    private LocalDateTime competitionStart;
 
     @Column(name = "competition_end", nullable = true)
     @Temporal(value = TemporalType.TIMESTAMP)
-    private Date competitionEnd;
+    private LocalDateTime competitionEnd;
 
     @Column(name = "competition_content", nullable = true, length = 2000)
     private String competitionContent;

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
@@ -16,8 +16,8 @@ public enum ErrorType {
     NOT_FOUND_MAJOR(400, "전공이 존재하지 않습니다"),
     NOT_FOUND_EXPERIENCE(400, "경험이 존재하지 않습니다"),
     NOT_FOUND_UNIVERSITY(400, "대학이 존재하지 않습니다"),
-    NOT_FOUND_USERSKILLSETRELATION(400, "유저와 스킬셋의 관계가 존재하지 않습니다");
-
+    NOT_FOUND_USERSKILLSETRELATION(400, "유저와 스킬셋의 관계가 존재하지 않습니다"),
+    NOT_FOUND_COMPETITION(400, "공모전이 존재하지 않습니다");
     private int code;
     private String message;
 

--- a/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Repository;
@@ -33,6 +34,10 @@ public interface CompetitionRepository extends JpaRepository<Competition, Long> 
 
     @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE c.competitionName LIKE %:keyword%")
     List<Competition> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Modifying
+    @Query("update Competition c set c.competitionVisit = c.competitionVisit +1 where c.competitionId = :id")
+    int updateVisit(@Param("id")Long id);
 
 }
 

--- a/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
@@ -5,8 +5,11 @@ import com.PuzzleU.Server.common.ResponseUtils;
 import com.PuzzleU.Server.dto.competition.CompetitionDto;
 import com.PuzzleU.Server.dto.competition.CompetitionHomePageDto;
 import com.PuzzleU.Server.dto.competition.CompetitionHomeTotalDto;
+import com.PuzzleU.Server.dto.competition.CompetitionSpecificDto;
 import com.PuzzleU.Server.entity.competition.Competition;
 import com.PuzzleU.Server.entity.enumSet.CompetitionType;
+import com.PuzzleU.Server.entity.enumSet.ErrorType;
+import com.PuzzleU.Server.exception.RestApiException;
 import com.PuzzleU.Server.repository.CompetitionRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +20,10 @@ import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -83,7 +88,35 @@ public class CompetitionService {
 
         return ResponseUtils.ok(competitionHomeTotalDto, null);
     }
+    @Transactional
+    public ApiResponseDto<CompetitionSpecificDto> getSpecific (Long competitionId)
+    {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        CompetitionSpecificDto competitionSpecificDto = competitionRepository.findById(competitionId)
+                .map(competition -> CompetitionSpecificDto.builder()
+                        .competitionId(competition.getCompetitionId())
+                        .competitionName(competition.getCompetitionName())
+                        .competitionUrl(competition.getCompetitionUrl())
+                        .competitionHost(competition.getCompetitionHost())
+                        .competitionPoster(competition.getCompetitionPoster())
+                        .competitionAwards(competition.getCompetitionAwards())
+                        .competitionStart(competition.getCompetitionStart().format(formatter))
+                        .competitionEnd(competition.getCompetitionEnd().format(formatter))
+                        .competitionContent(competition.getCompetitionContent())
+                        .competitionVisit(competition.getCompetitionVisit()+1)
+                        .competitionLike(competition.getCompetitionLike())
+                        .competitionMatching(competition.getCompetitionMatching())
+                        .competitionDDay(competition.getCompetitionDDay())
+                        .competitionTypes(competition.getCompetitionTypes())
+                        .build())
+                .orElseThrow(() -> {
+                    System.out.println("Competition not found");
+                    return new RestApiException(ErrorType.NOT_FOUND_COMPETITION);
+                });
+        competitionRepository.updateVisit(competitionId);
 
-
+        return ResponseUtils.ok(competitionSpecificDto, null);
+    }
+    // 최신순, 마감빠른순, 마감느린순, 인기순, 조회순, 팀빌딩순
 
 }


### PR DESCRIPTION
# 공모전 상세페이지 get 구현
## 공모전 상세페이지에서
private Long competitionId;
    @Size(max = 100)
    private String competitionName;
    @Size(max =200)
    private String competitionUrl;
    @Size(max = 50)
    private String competitionHost;
    @Size(max = 200)
    private String competitionPoster;
    @Size(max =50)
    private String competitionAwards;

    private String competitionStart;
    private String competitionEnd;
    @Size(max = 2000)
    private String competitionContent;
    private Integer competitionVisit;
    private Integer competitionLike;
    private Integer competitionMatching;
    private Integer competitionDDay;
    private List<CompetitionType> competitionTypes;
데이터를 불러와서 전달해 줍니다
## Competition Entity 변경
# Date를 LocalDate로 변경하고 yyyy-MM-dd HH:mm 형식으로 변환하기위한 formatter 형식을 Service에서 구현하였습니다