### PR TITLE
[FEAT] #34 회원가입 필수 정보 저장 기능 구현

### DIFF
--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.controller;
 
 import com.PuzzleU.Server.common.ApiResponseDto;
+import com.PuzzleU.Server.common.ResponseUtils;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.experience.ExperienceDto;
 import com.PuzzleU.Server.dto.relation.UserSkillsetRelationDto;
@@ -21,6 +22,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.bouncycastle.cert.ocsp.Req;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -122,6 +126,12 @@ public class UserController {
             )
     {
         return universityService.createUniversity(userId,userUniversityDto);
+    }
+
+    // 로그인한 유저 정보 받아오기 테스트
+    @GetMapping("/usernametest")
+    public ApiResponseDto<SuccessResponse> findUserName(@AuthenticationPrincipal UserDetails user) {
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, user.getUsername()), null);
     }
 }
 

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -128,10 +128,12 @@ public class UserController {
         return universityService.createUniversity(userId,userUniversityDto);
     }
 
-    // 로그인한 유저 정보 받아오기 테스트
-    @GetMapping("/usernametest")
-    public ApiResponseDto<SuccessResponse> findUserName(@AuthenticationPrincipal UserDetails user) {
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, user.getUsername()), null);
-    }
+//    // 로그인한 유저 정보 받아오기 테스트
+//    @GetMapping("/usernametest")
+//    public ApiResponseDto<SuccessResponse> findUserName(@AuthenticationPrincipal UserDetails user) {
+//        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, user.getUsername()), null);
+//    }
+
+
 }
 

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -8,10 +8,7 @@ import com.PuzzleU.Server.dto.relation.UserSkillsetRelationDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetListDto;
 import com.PuzzleU.Server.dto.university.UniversityDto;
-import com.PuzzleU.Server.dto.user.LoginRequestsDto;
-import com.PuzzleU.Server.dto.user.SignupRequestDto;
-import com.PuzzleU.Server.dto.user.UserRegisterOptionalDto;
-import com.PuzzleU.Server.dto.user.UserUniversityDto;
+import com.PuzzleU.Server.dto.user.*;
 import com.PuzzleU.Server.entity.relations.UserSkillsetRelation;
 import com.PuzzleU.Server.service.User.UserService;
 import com.PuzzleU.Server.service.experience.ExperienceService;
@@ -133,6 +130,14 @@ public class UserController {
 //    public ApiResponseDto<SuccessResponse> findUserName(@AuthenticationPrincipal UserDetails user) {
 //        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, user.getUsername()), null);
 //    }
+
+    @PatchMapping("/essential")
+    public ApiResponseDto<SuccessResponse> registerEssential(
+            @AuthenticationPrincipal UserDetails loginUser,
+            @RequestBody UserRegisterEssentialDto userRegisterEssentialDto
+    ) {
+        return userService.registerEssential(loginUser, userRegisterEssentialDto);
+    }
 
 
 }

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -125,12 +125,6 @@ public class UserController {
         return universityService.createUniversity(userId,userUniversityDto);
     }
 
-//    // 로그인한 유저 정보 받아오기 테스트
-//    @GetMapping("/usernametest")
-//    public ApiResponseDto<SuccessResponse> findUserName(@AuthenticationPrincipal UserDetails user) {
-//        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, user.getUsername()), null);
-//    }
-
     @PatchMapping("/essential")
     public ApiResponseDto<SuccessResponse> registerEssential(
             @AuthenticationPrincipal UserDetails loginUser,

--- a/src/main/java/com/PuzzleU/Server/dto/user/UserRegisterEssentialDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/user/UserRegisterEssentialDto.java
@@ -1,0 +1,21 @@
+package com.PuzzleU.Server.dto.user;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class UserRegisterEssentialDto {
+    private String UserKoreaName;
+    private String UserPuzzleId;
+    private Long UserProfileId; // 우선 순위 1
+    private Long UserPositionId1; // 우선 순위 2
+    private Long UserPositionId2;
+    private List<Long> UserInterestIdList;
+    private List<Long> UserLocationIdList;
+}

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/ErrorType.java
@@ -17,11 +17,16 @@ public enum ErrorType {
     NOT_FOUND_EXPERIENCE(400, "경험이 존재하지 않습니다"),
     NOT_FOUND_UNIVERSITY(400, "대학이 존재하지 않습니다"),
     NOT_FOUND_USERSKILLSETRELATION(400, "유저와 스킬셋의 관계가 존재하지 않습니다"),
+    NOT_FOUND_POSITION(400, "포지션이 존재하지 않습니다."),
+    NOT_FOUND_INTEREST(400, "관심 분야가 존재하지 않습니다."),
+    NOT_FOUND_LOCATION(400, "지역이 존재하지 않습니다."),
+    NOT_FOUND_PROFILE(400, "프로필이 존재하지 않습니다."),
     NOT_FOUND_COMPETITION(400, "공모전이 존재하지 않습니다"),
     NOT_FOUND_POSITION_LIST(404, "포지션 리스트가 존재하지 않습니다."),
     NOT_FOUND_INTEREST_LIST(404, "관심 분야 리스트가 존재하지 않습니다."),
     NOT_FOUND_LOCATION_LIST(404, "지역 리스트가 존재하지 않습니다."),
-    NOT_FOUND_PROFILE_LIST(404, "프로필 리스트가 존재하지 않습니다.");
+    NOT_FOUND_PROFILE_LIST(404, "프로필 리스트가 존재하지 않습니다."),
+    TOO_MUCH_LOCATIONS(400, "너무 많은 지역이 입력되었습니다. 지역은 최대 2개까지 선택 가능합니다.");
 
     private int code;
     private String message;

--- a/src/main/java/com/PuzzleU/Server/entity/enumSet/Priority.java
+++ b/src/main/java/com/PuzzleU/Server/entity/enumSet/Priority.java
@@ -1,0 +1,5 @@
+package com.PuzzleU.Server.entity.enumSet;
+
+public enum Priority {
+    FIRST, SECOND
+}

--- a/src/main/java/com/PuzzleU/Server/entity/relations/UserInterestRelation.java
+++ b/src/main/java/com/PuzzleU/Server/entity/relations/UserInterestRelation.java
@@ -3,10 +3,7 @@ package com.PuzzleU.Server.entity.relations;
 import com.PuzzleU.Server.entity.interest.Interest;
 import com.PuzzleU.Server.entity.user.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "User_interest_relation")
@@ -14,6 +11,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class UserInterestRelation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/PuzzleU/Server/entity/relations/UserLocationRelation.java
+++ b/src/main/java/com/PuzzleU/Server/entity/relations/UserLocationRelation.java
@@ -4,10 +4,7 @@ import com.PuzzleU.Server.entity.interest.Interest;
 import com.PuzzleU.Server.entity.location.Location;
 import com.PuzzleU.Server.entity.user.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "user_location_relation")
@@ -15,6 +12,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class UserLocationRelation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/PuzzleU/Server/entity/relations/UserPositionRelation.java
+++ b/src/main/java/com/PuzzleU/Server/entity/relations/UserPositionRelation.java
@@ -1,23 +1,25 @@
 package com.PuzzleU.Server.entity.relations;
 
 import com.PuzzleU.Server.entity.apply.Apply;
+import com.PuzzleU.Server.entity.enumSet.Priority;
 import com.PuzzleU.Server.entity.position.Position;
 import com.PuzzleU.Server.entity.user.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class UserPositionRelation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userPositionRelationId;
+
+    @Enumerated(EnumType.STRING)
+    private Priority positionPriority;
 
     // 의존 관계 매핑 (User)
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/PuzzleU/Server/jwt/JwtUtil.java
+++ b/src/main/java/com/PuzzleU/Server/jwt/JwtUtil.java
@@ -56,10 +56,12 @@ public class JwtUtil {
         // Authorization 헤더의 값을 가져온다 - 클라이언트가 서버에게 토큰을 전달하기 위해 사용되는 문자열이 포함
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         // bearerToken이 null이 아니고 비어있는지 확인, 헤더에 Authorization키가 있고 그값이 비어 있지 않은지를 체크
+
+//        System.out.println("resolveToken token: " + bearerToken);
         if (StringUtils.hasText(bearerToken)&& bearerToken.startsWith(BEARER_PREFIX))
         {
             // Bearer의 길이가 7이므로 7번째 문자부터 끝까지를 반환
-            return bearerToken.substring(7);
+            return bearerToken.substring(BEARER_PREFIX.length());
         }
         // 형식이 맞지 않으면 null을 반환
         return null;
@@ -84,9 +86,10 @@ public class JwtUtil {
 
     public boolean validateToken(String token)
     {
+//        System.out.println("validate token: " + token);
         try{
             // jwt파싱을 위한 객체 생성 / 토큰의 서명 검증을 위해 사용할 키 설정 / 파서 생성 / 토큰을 파싱하고 클레임을 가져옴
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         }catch (SecurityException | MalformedJwtException e)
         {
@@ -106,8 +109,12 @@ public class JwtUtil {
     // 토큰에서 사용자 정보 가져오기 (클레임에 존재)
     public Claims getUserInfoFromToken(String token)
     {
-        // jwt 파싱하기 위한 빌더 객체 생성 / 토큰의 서명 검증을 위해 사용할 키 설정 / 파싱 생성 / 토큰을 파싱하고 클레임을 가져옴 / 토큰의 본문을 반환
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token).getBody();
+        String cleanToken = token.replace(BEARER_PREFIX, "");
+//        System.out.println("getUserInfoFromToken token: " + cleanToken);
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(cleanToken).getBody();
+        
+//        // jwt 파싱하기 위한 빌더 객체 생성 / 토큰의 서명 검증을 위해 사용할 키 설정 / 파싱 생성 / 토큰을 파싱하고 클레임을 가져옴 / 토큰의 본문을 반환
+//        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
 
     // 사용자의 인증 정보를 가져온다

--- a/src/main/java/com/PuzzleU/Server/repository/InterestRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/InterestRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface InterestRepository extends JpaRepository<Interest, Long> {
     List<Interest> findByInterestType(InterestTypes interestType);
+    Optional<Interest> findByInterestId(Long interestId);
 }

--- a/src/main/java/com/PuzzleU/Server/repository/LocationRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/LocationRepository.java
@@ -4,6 +4,9 @@ import com.PuzzleU.Server.entity.location.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
+    Optional<Location> findByLocationId(Long locationId);
 }

--- a/src/main/java/com/PuzzleU/Server/repository/PositionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/PositionRepository.java
@@ -3,5 +3,9 @@ package com.PuzzleU.Server.repository;
 import com.PuzzleU.Server.entity.position.Position;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
 public interface PositionRepository extends JpaRepository<Position, Long> {
+    Optional<Position> findByPositionId(Long positionId);
 }

--- a/src/main/java/com/PuzzleU/Server/repository/ProfileRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/ProfileRepository.java
@@ -4,6 +4,9 @@ import com.PuzzleU.Server.entity.profile.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    Optional<Profile> findByProfileId(Long profileId);
 }


### PR DESCRIPTION
### 회원가입 필수 정보 저장 기능 구현
로그인한 유저가 자신의 회원가입 필수 정보를 저장하는 매서드를 구현했습니다. 이 매서드에서 저장하는 정보는 다음과 같습니다.
- userKoreaName
- userPuzzleId
- userProfileId
- userPositionId1
- userPositionId2
- userInterestIdList
- userLocationIdList

### 로그인한 유저 정보 받아오기
jwtUntil를 일부 수정했습니다.

--- controller에서 파라미터로 `@AuthenticationPrincipal UserDetails loginUser`를 넘깁니다.

예시)
``` java
    @PatchMapping("/essential")
    public ApiResponseDto<SuccessResponse> registerEssential(
            @AuthenticationPrincipal UserDetails loginUser,
            @RequestBody UserRegisterEssentialDto userRegisterEssentialDto
    ) {
        return userService.registerEssential(loginUser, userRegisterEssentialDto);
    }
```

참고) https://velog.io/@tnals1178/Spring-Security-%EB%B3%B5%EC%8A%B5-JWT-%EC%9D%B8%EC%A6%9D-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EB%B3%B4-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0

### UserPositionRelationshipEntity에 우선 순위 추가
유저가 회원가입할 때 선택하는 포지션에는 우선순위가 있기 때문에, Propertiy(Enumtype) 필드를 추가했습니다.