### PR TITLE
[FEAT]  친구검색(친구리스트 GET)

### DIFF
--- a/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/config/WebSecurityConfig.java
@@ -54,6 +54,8 @@ public class WebSecurityConfig {
                                 .requestMatchers("/api/user/**").permitAll()
                                 .requestMatchers("/api/competition/**").permitAll()
                                 .requestMatchers("/api/oauth/**").permitAll()
+                                .requestMatchers("/api/team/**").permitAll()
+
                                 .requestMatchers(HttpMethod.GET,"/api/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/post/{id}").permitAll()
                                 .requestMatchers(HttpMethod.GET, "api/splash").permitAll()

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.controller;
 import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.competition.CompetitionSearchDto;
+import com.PuzzleU.Server.dto.friendship.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.dto.team.TeamCreateDto;
 import com.PuzzleU.Server.dto.user.SignupRequestDto;
 import com.PuzzleU.Server.service.User.UserService;
@@ -24,10 +25,17 @@ public class TeamController {
     public ApiResponseDto<SuccessResponse> teamCreate(@Valid @RequestBody TeamCreateDto teamCreateDto) {
         return teamService.teamcreate(teamCreateDto);
     }
-    @GetMapping("/search/{keyword}")
-    public ApiResponseDto<List<CompetitionSearchDto>> forteamsearch(@Valid
+    @GetMapping("/searchCompetition/{keyword}")
+    public ApiResponseDto<List<CompetitionSearchDto>> competitionSearch(@Valid
                                                                     @PathVariable String keyword)
     {
         return teamService.competitionTeamSearch(keyword);
     }
+    @GetMapping("/searchMember/{userId}/{keyword}")
+    public ApiResponseDto<FriendShipSearchResponseDto> memberSearch(@Valid
+                                                                    @PathVariable String keyword, @PathVariable Long userId)
+    {
+        return teamService.firendRegister(keyword, userId);
+    }
+
 }

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -10,6 +10,8 @@ import com.PuzzleU.Server.service.User.UserService;
 import com.PuzzleU.Server.service.team.TeamService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,11 +33,11 @@ public class TeamController {
     {
         return teamService.competitionTeamSearch(keyword);
     }
-    @GetMapping("/searchMember/{userId}/{keyword}")
+    @GetMapping("/searchMember/{keyword}")
     public ApiResponseDto<FriendShipSearchResponseDto> memberSearch(@Valid
-                                                                    @PathVariable String keyword, @PathVariable Long userId)
+         @PathVariable String keyword, @AuthenticationPrincipal UserDetails loginUser)
     {
-        return teamService.firendRegister(keyword, userId);
+        return teamService.firendRegister(keyword, loginUser);
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -133,6 +133,6 @@ public class UserController {
         return userService.registerEssential(loginUser, userRegisterEssentialDto);
     }
 
-
+//2
 }
 

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -52,77 +52,77 @@ public class UserController {
         return userService.login(requestDto, response);
     }
 
-    @PatchMapping("/optional/{userId}")
+    @PatchMapping("/optional")
     public ApiResponseDto<SuccessResponse> registerOptional(@Valid
             @RequestBody UserRegisterOptionalDto userRegisterOptionalDto,
-            @PathVariable Long userId)
+            @AuthenticationPrincipal UserDetails loginUser)
     {
-        return userService.createRegisterOptionalUser(userId,userRegisterOptionalDto);
+        return userService.createRegisterOptionalUser(loginUser,userRegisterOptionalDto);
     }
-    @PostMapping("/experience/{userId}")
+    @PostMapping("/experience")
     public ApiResponseDto<SuccessResponse> postExperience(@Valid
-            @RequestBody ExperienceDto experienceDto,
-            @PathVariable Long userId)
+            @RequestBody ExperienceDto experienceDto, @AuthenticationPrincipal UserDetails loginUser)
     {
-        return experienceService.createExperience(userId,experienceDto);
+        return experienceService.createExperience(loginUser,experienceDto);
     }
-    @PatchMapping("/experience/{userId}/{experienceId}")
+    @PatchMapping("/experience/{experienceId}")
     public ApiResponseDto<SuccessResponse> updateExperience(@Valid
-            @RequestBody ExperienceDto experienceDto,
-            @PathVariable Long userId, @PathVariable Long experienceId)
+            @RequestBody ExperienceDto experienceDto, @AuthenticationPrincipal UserDetails loginUser, @PathVariable Long experienceId)
     {
-        return experienceService.updateExperience(userId, experienceId,experienceDto);
+        return experienceService.updateExperience(loginUser, experienceId,experienceDto);
     }
-    @DeleteMapping("/experience/{userId}/{experienceId}")
+    @DeleteMapping("/experience/{experienceId}")
     public ApiResponseDto<SuccessResponse> deleteExperience(@Valid
-            @PathVariable Long userId, @PathVariable Long experienceId)
+            @AuthenticationPrincipal UserDetails loginUser
+            , @PathVariable Long experienceId)
     {
-        return experienceService.deleteExperience(userId, experienceId);
+        return experienceService.deleteExperience(loginUser, experienceId);
     }
-    @GetMapping("/experience/{userId}")
+    @GetMapping("/experience")
     public ApiResponseDto<List<ExperienceDto>> getExperienceList(@Valid
-            @PathVariable Long userId
+           @AuthenticationPrincipal UserDetails loginUser
     )
     {
-        return experienceService.getExperienceList(userId);
+        return experienceService.getExperienceList(loginUser);
     }
-    @GetMapping("/experience/{userId}/{experienceId}")
+    @GetMapping("/experience/{experienceId}")
     public ApiResponseDto<ExperienceDto> getExperience(@Valid
-            @PathVariable Long userId, @PathVariable Long experienceId
+          @AuthenticationPrincipal UserDetails loginUser, @PathVariable Long experienceId
     )
     {
-        return experienceService.getExperience(userId,experienceId);
+        return experienceService.getExperience(loginUser,experienceId);
     }
-    @PostMapping("/skillset/{userId}")
+    @PostMapping("/skillset")
     public ApiResponseDto<SuccessResponse> createSkillset(@Valid
-            @PathVariable Long userId,
+            @AuthenticationPrincipal UserDetails loginUser,
             @RequestBody SkillSetListDto skillsetList
     )
     {
-        return skillsetService.createSkillset(userId, skillsetList);
+        return skillsetService.createSkillset(loginUser, skillsetList);
     }
-    @DeleteMapping("/skillset/{userId}/{skillsetId}")
+    @DeleteMapping("/skillset/{skillsetId}")
     public ApiResponseDto<SuccessResponse> deleteSkillset(@Valid
-            @PathVariable Long userId,
+            @AuthenticationPrincipal UserDetails loginUser,
             @PathVariable Long skillsetId
     )
     {
-        return skillsetService.deleteSkillset(userId, skillsetId);
+        return skillsetService.deleteSkillset(loginUser, skillsetId);
     }
-    @GetMapping("/skillset/{userId}")
+    @GetMapping("/skillset")
     public ApiResponseDto<List<UserSkillsetRelationDto>> getUserSkillsetList(@Valid
-            @PathVariable Long userId
+            @AuthenticationPrincipal UserDetails loginUser
+
     )
     {
-        return skillsetService.getSkillsetList(userId);
+        return skillsetService.getSkillsetList(loginUser);
     }
-    @PatchMapping("/university/{userId}")
+    @PatchMapping("/university")
     public ApiResponseDto<SuccessResponse> createUniversity(@Valid
-            @PathVariable Long userId,
+            @AuthenticationPrincipal UserDetails loginUser,
             @RequestBody UserUniversityDto userUniversityDto
             )
     {
-        return universityService.createUniversity(userId,userUniversityDto);
+        return universityService.createUniversity(loginUser, userUniversityDto);
     }
 
     @PatchMapping("/essential")

--- a/src/main/java/com/PuzzleU/Server/dto/friendship/FriendShipSearchResponseDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/friendship/FriendShipSearchResponseDto.java
@@ -1,0 +1,20 @@
+package com.PuzzleU.Server.dto.friendship;
+
+import com.PuzzleU.Server.dto.user.UserSimpleDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FriendShipSearchResponseDto {
+    // 유저의 이름, 한줄소개
+    @JsonProperty("FriendList")
+    private List<UserSimpleDto> userSimpleDtoList;
+
+}

--- a/src/main/java/com/PuzzleU/Server/dto/user/UserSimpleDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/user/UserSimpleDto.java
@@ -1,0 +1,20 @@
+package com.PuzzleU.Server.dto.user;
+
+import com.PuzzleU.Server.entity.profile.Profile;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class UserSimpleDto {
+    private String UserKoreaName;
+    private Profile userProfile;
+
+    private String userRepresentativeProfileSentence;
+
+    private Long userId;
+
+}

--- a/src/main/java/com/PuzzleU/Server/entity/friendship/FriendShip.java
+++ b/src/main/java/com/PuzzleU/Server/entity/friendship/FriendShip.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @Entity
 @Table(name = "friendship")
@@ -28,6 +30,7 @@ public class FriendShip {
     @JoinColumn(name = "users2")
     private User user2;
 
+    @ColumnDefault("false")
     @Column(name = "user_status")
     private Boolean userStatus;
 

--- a/src/main/java/com/PuzzleU/Server/repository/FriendshipRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/FriendshipRepository.java
@@ -1,9 +1,20 @@
 package com.PuzzleU.Server.repository;
 
 import com.PuzzleU.Server.entity.friendship.FriendShip;
+import com.PuzzleU.Server.entity.user.User;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FriendshipRepository extends JpaRepository<FriendShip, Long> {
+
+
+    @Query("SELECT f FROM FriendShip f WHERE ((f.user1 = :user AND f.user2.userKoreaName LIKE %:keyword%) OR (f.user2 = :user AND f.user1.userKoreaName LIKE %:keyword%)) AND f.userStatus = true")
+    List<FriendShip> findActiveFriendshipsForUserAndKeyword(@Param("user") User user, @Param("keyword") String keyword);
+
+
 }

--- a/src/main/java/com/PuzzleU/Server/service/User/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/service/User/UserService.java
@@ -107,16 +107,13 @@ public class UserService {
 
     }
     public ApiResponseDto<SuccessResponse> createRegisterOptionalUser(
-            Long userId,
+            UserDetails loginUser,
             UserRegisterOptionalDto userRegisterOptionalDto
     ) {
-        System.out.println("userId:" + userId);
 
-        if (userId == null) {
-            throw new RestApiException(ErrorType.NOT_FOUND_USER);
-        }
-        System.out.println(userRegisterOptionalDto);
-        Optional<User> optionalUser = userRepository.findById(userId);
+
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         if(userRegisterOptionalDto.getUniversityStart() == null)
         {
             System.out.println("null");
@@ -127,10 +124,7 @@ public class UserService {
         Optional<University> optionalUniversity = universityRepository.findById(userRegisterOptionalDto.getUniversityId());
         System.out.println(optionalUniversity);
 
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+
 
         Major major = optionalMajor.orElseThrow(() -> {
             System.out.println("Major not found");

--- a/src/main/java/com/PuzzleU/Server/service/experience/ExperienceService.java
+++ b/src/main/java/com/PuzzleU/Server/service/experience/ExperienceService.java
@@ -13,6 +13,7 @@ import com.PuzzleU.Server.repository.ExperienceRepository;
 import com.PuzzleU.Server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -28,15 +29,12 @@ public class ExperienceService {
 
 
     public ApiResponseDto<SuccessResponse> createExperience(
-            Long userId,
+            UserDetails loginUser,
             ExperienceDto experienceDto
     )
     {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Experience experience = new Experience();
         experience.setUser(user);
         experience.setExperienceName(experienceDto.getExperienceName());
@@ -52,16 +50,13 @@ public class ExperienceService {
 
     }
     public ApiResponseDto<SuccessResponse> updateExperience(
-            Long userId,
+            UserDetails loginUser,
             Long experienceId,
             ExperienceDto experienceDto
     )
     {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Experience> optionalExperience = experienceRepository.findByExperienceIdAndUser(experienceId,user);
         Experience experience = optionalExperience.orElseThrow(() -> {
             System.out.println("User not found");
@@ -105,14 +100,11 @@ public class ExperienceService {
 
     }
     public ApiResponseDto<SuccessResponse> deleteExperience(
-            Long userId,Long experienceId
+            UserDetails loginUser,Long experienceId
     )
     {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Experience> optionalExperience = experienceRepository.findByExperienceIdAndUser(experienceId,user);
         Experience experience = optionalExperience.orElseThrow(() -> {
             System.out.println("User not found");
@@ -121,9 +113,9 @@ public class ExperienceService {
         experienceRepository.delete(experience);
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 삭제완료"), null);
     }
-    public ApiResponseDto<List<ExperienceDto>> getExperienceList(Long userId) {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> new RestApiException(ErrorType.NOT_MATCHING_INFO));
+    public ApiResponseDto<List<ExperienceDto>> getExperienceList(UserDetails loginUser) {
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
 
         List<ExperienceDto> experienceList = new ArrayList<>();
         List<Experience> userExperiences = experienceRepository.findByUser(user);
@@ -144,12 +136,9 @@ public class ExperienceService {
         return ResponseUtils.ok(experienceList, null);
 
     }
-    public ApiResponseDto<ExperienceDto> getExperience(Long userId, Long experienceId) {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+    public ApiResponseDto<ExperienceDto> getExperience(UserDetails loginUser, Long experienceId) {
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Experience> optionalExperience = experienceRepository.findByExperienceIdAndUser(experienceId,user);
         Experience experience = optionalExperience.orElseThrow(() -> {
             System.out.println("User not found");

--- a/src/main/java/com/PuzzleU/Server/service/skillset/SkillsetService.java
+++ b/src/main/java/com/PuzzleU/Server/service/skillset/SkillsetService.java
@@ -19,6 +19,7 @@ import com.PuzzleU.Server.repository.UserSkillsetRelationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -34,15 +35,12 @@ public class SkillsetService {
     private final SkillsetRepository skillsetRepository;
     private final UserSkillsetRelationRepository userSkillsetRelationRepository;
     public ApiResponseDto<SuccessResponse> createSkillset(
-            Long userId, SkillSetListDto skillsetList
+            UserDetails loginUser, SkillSetListDto skillsetList
     )
     {
         // skillset id 로 skillset을 찾고 userid로 user를 찾고 넣어주면 된다. 중복가능
-        Optional<User> userOptional = userRepository.findById(userId);
-        User user = userOptional.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         // 리스트형식인 skillsetlistdto 에서 for문 돌려서 하나씩 dto오를 참여해서 각각 s, u , l 을 설정한 것을 하나씩 repository에 저장한다
         List<UserSkillsetRelation> userSkillsetRelationList = new ArrayList<>();
         for(SkillSetDto skillsetDto : skillsetList.getSkillSetDtoList())
@@ -63,14 +61,11 @@ public class SkillsetService {
 
     }
     public ApiResponseDto<SuccessResponse> deleteSkillset(
-            Long userId, Long skillsetId
+            UserDetails loginUser, Long skillsetId
     )
     {
-        Optional<User> userOptional = userRepository.findById(userId);
-        User user = userOptional.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Skillset> userSkillset = skillsetRepository.findById(skillsetId);
         Skillset skillset = userSkillset.orElseThrow(() -> {
             System.out.println("Skillset not found");
@@ -85,9 +80,9 @@ public class SkillsetService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 삭제완료"), null);
 
     }
-    public ApiResponseDto<List<UserSkillsetRelationDto>> getSkillsetList(Long userId) {
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> new RestApiException(ErrorType.NOT_MATCHING_INFO));
+    public ApiResponseDto<List<UserSkillsetRelationDto>> getSkillsetList(UserDetails loginUser) {
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
 
 
         List<UserSkillsetRelation> userSkillsetRelation = userSkillsetRelationRepository.findByUser(user);

--- a/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
@@ -4,14 +4,22 @@ import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.ResponseUtils;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.competition.CompetitionSearchDto;
+import com.PuzzleU.Server.dto.friendship.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.dto.team.TeamCreateDto;
+import com.PuzzleU.Server.dto.user.UserSimpleDto;
+import com.PuzzleU.Server.entity.enumSet.ErrorType;
+import com.PuzzleU.Server.entity.friendship.FriendShip;
+import com.PuzzleU.Server.entity.user.User;
+import com.PuzzleU.Server.exception.RestApiException;
 import com.PuzzleU.Server.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -49,5 +57,47 @@ public class TeamService {
                 .collect(Collectors.toList());
 
         return ResponseUtils.ok(competitionSearchDtos, null);
+    }
+    // 유저 정보 리스트를 가져오고 여기에는 유저의 이름, id, 한줄소개가 있어야한다.
+    @Transactional
+    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, Long userId)
+    {
+        System.out.println(userId);
+        System.out.println(keyword);
+        Optional<User> optionalUser = userRepository.findById(userId);
+        User user = optionalUser.orElseThrow(() -> {
+            System.out.println("User not found");
+            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
+        });
+        FriendShipSearchResponseDto friendShipSearchResponseDto = new FriendShipSearchResponseDto();
+        // 각각의 friendshipe에 대해서 user가 아닌 user에 대한 정보를 저장하고 리스트로 만들어준다
+        List<FriendShip> friendShipList = friendshipRepository.findActiveFriendshipsForUserAndKeyword(user, keyword);
+        List<UserSimpleDto> userSimpleDtoList = new ArrayList<>();
+        for(FriendShip friendShip:friendShipList)
+        {
+            User user1 = friendShip.getUser1();
+            User user2 = friendShip.getUser2();
+            if (user1 == user)
+            {
+                UserSimpleDto userSimpleDto = new UserSimpleDto();
+                userSimpleDto.setUserProfile(user2.getUserProfile());
+                userSimpleDto.setUserKoreaName(user2.getUserKoreaName());
+                userSimpleDto.setUserRepresentativeProfileSentence(user2.getUserRepresentativeProfileSentence());
+                userSimpleDto.setUserId(user2.getId());
+                userSimpleDtoList.add(userSimpleDto);
+
+            }
+            else {
+                UserSimpleDto userSimpleDto = new UserSimpleDto();
+                userSimpleDto.setUserProfile(user1.getUserProfile());
+                userSimpleDto.setUserKoreaName(user1.getUserKoreaName());
+                userSimpleDto.setUserRepresentativeProfileSentence(user1.getUserRepresentativeProfileSentence());
+                userSimpleDto.setUserId(user1.getId());
+                userSimpleDtoList.add(userSimpleDto);
+
+            }
+        }
+        friendShipSearchResponseDto.setUserSimpleDtoList(userSimpleDtoList);
+     return ResponseUtils.ok(friendShipSearchResponseDto, null)  ;
     }
 }

--- a/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
@@ -15,6 +15,7 @@ import com.PuzzleU.Server.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -60,15 +61,10 @@ public class TeamService {
     }
     // 유저 정보 리스트를 가져오고 여기에는 유저의 이름, id, 한줄소개가 있어야한다.
     @Transactional
-    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, Long userId)
+    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, UserDetails loginUser)
     {
-        System.out.println(userId);
-        System.out.println(keyword);
-        Optional<User> optionalUser = userRepository.findById(userId);
-        User user = optionalUser.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         FriendShipSearchResponseDto friendShipSearchResponseDto = new FriendShipSearchResponseDto();
         // 각각의 friendshipe에 대해서 user가 아닌 user에 대한 정보를 저장하고 리스트로 만들어준다
         List<FriendShip> friendShipList = friendshipRepository.findActiveFriendshipsForUserAndKeyword(user, keyword);

--- a/src/main/java/com/PuzzleU/Server/service/university/UniversityService.java
+++ b/src/main/java/com/PuzzleU/Server/service/university/UniversityService.java
@@ -18,6 +18,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -32,15 +33,13 @@ public class UniversityService {
 
     @Transactional
     public ApiResponseDto<SuccessResponse> createUniversity(
-            Long userId, UserUniversityDto userUniversityDto
+            UserDetails loginUser, UserUniversityDto userUniversityDto
     )
     {
         // 유저정보 저장해주고
-        Optional<User> userOptional = userRepository.findById(userId);
-        User user = userOptional.orElseThrow(() -> {
-            System.out.println("User not found");
-            return new RestApiException(ErrorType.NOT_MATCHING_INFO);
-        });
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
         // unviersityid로 id값 얻고
         // majorid로 id값 얻어서
         // 한번에 dto에 저장하고 repository에 저장


### PR DESCRIPTION
### 친구검색으로인한 친구 찾기 기능 구현
친구를 검색했을때 친구이름을 검색하여서 친구 리스트를 얻을 수 있는 기능을 구현하였습니다
이를 통해 친구한국이름, 친구ID, 친구 대표 설명, 프로필을 얻을 수 있습니다
"userProfile"
"userRepresentativeProfileSentence": "ProfileSentence4",
"userId": 9,
"userKoreaName": "김성헌"
### FriendShip 관해서 논의해야하는 점
일단 구현할때 user1, user2에서 만약에 로그인을 한 사용자가 존재한다면, 다른 user를 찾아서 검색하도록 설정하였습니다
user1과 user2를 구분해야하나는 점때문에 코드가 길어질 수도 있고 복잡한데
만약에 친구관계를 표시하는 FriendShip데이터를 생성할때는 중복으로 ex) 1. user1 = 성현, user2= 정연 / 2. user1=정연, user1= 성현
생성이 안되도록 지정해야할 것 같습니다
## user url 변경
{userId}가 되어 있었던 url 코드 (controller와 service)를 모두 변경해 주었습니다
