### PR TITLE
FEAT/FIX 공모전/팀원 검색 후 데이터 받는 기능 구현(Pagination)

### DIFF
--- a/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/CompetitionController.java
@@ -29,7 +29,7 @@ public class CompetitionController {
             @RequestParam(value = "search", defaultValue = "None", required = false) String search,
             @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
-            @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy
+            @RequestParam(value = "sortBy", defaultValue = "CompetitionId", required = false) String sortBy
     ) {
         return competitionService.getHomepage(pageNo, pageSize, sortBy, search, competitionType);
     }

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -46,7 +46,7 @@ public class TeamController {
             @RequestParam(value = "sortBy", defaultValue = "friendshipId", required = false) String sortBy,
             @AuthenticationPrincipal UserDetails loginUser)
     {
-        return teamService.firendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
+        return teamService.frIendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -31,17 +31,22 @@ public class TeamController {
     @GetMapping("/searchCompetition")
     public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid
       @RequestParam(value = "search", defaultValue = "None", required = false) String keyword,
-                                                                             @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
-                                                                       @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
-                                                                             @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy)
+      @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+      @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+      @RequestParam(value = "sortBy", defaultValue = "competitionId", required = false) String sortBy)
     {
         return teamService.competitionTeamSearch(pageNo,pageSize, sortBy, keyword);
     }
-    @GetMapping("/searchMember/{keyword}")
-    public ApiResponseDto<FriendShipSearchResponseDto> memberSearch(@Valid
-         @PathVariable String keyword, @AuthenticationPrincipal UserDetails loginUser)
+    @GetMapping("/searchMember")
+    public ApiResponseDto<FriendShipSearchResponseDto> memberSearch(
+            @Valid
+            @RequestParam(value = "search", defaultValue = "None", required = false) String keyword,
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "friendshipId", required = false) String sortBy,
+            @AuthenticationPrincipal UserDetails loginUser)
     {
-        return teamService.firendRegister(keyword, loginUser);
+        return teamService.firendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -32,7 +32,7 @@ public class TeamController {
     public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid
       @RequestParam(value = "search", defaultValue = "None", required = false) String keyword,
                                                                              @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
-                                //2                                             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+                                                                       @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
                                                                              @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy)
     {
         return teamService.competitionTeamSearch(pageNo,pageSize, sortBy, keyword);

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -32,7 +32,7 @@ public class TeamController {
     public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid
       @RequestParam(value = "search", defaultValue = "None", required = false) String keyword,
                                                                              @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
-                                                                             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+                                //2                                             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
                                                                              @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy)
     {
         return teamService.competitionTeamSearch(pageNo,pageSize, sortBy, keyword);

--- a/src/main/java/com/PuzzleU/Server/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/TeamController.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.controller;
 import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.competition.CompetitionSearchDto;
+import com.PuzzleU.Server.dto.competition.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.dto.friendship.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.dto.team.TeamCreateDto;
 import com.PuzzleU.Server.dto.user.SignupRequestDto;
@@ -27,11 +28,14 @@ public class TeamController {
     public ApiResponseDto<SuccessResponse> teamCreate(@Valid @RequestBody TeamCreateDto teamCreateDto) {
         return teamService.teamcreate(teamCreateDto);
     }
-    @GetMapping("/searchCompetition/{keyword}")
-    public ApiResponseDto<List<CompetitionSearchDto>> competitionSearch(@Valid
-                                                                    @PathVariable String keyword)
+    @GetMapping("/searchCompetition")
+    public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid
+      @RequestParam(value = "search", defaultValue = "None", required = false) String keyword,
+                                                                             @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+                                                                             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+                                                                             @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy)
     {
-        return teamService.competitionTeamSearch(keyword);
+        return teamService.competitionTeamSearch(pageNo,pageSize, sortBy, keyword);
     }
     @GetMapping("/searchMember/{keyword}")
     public ApiResponseDto<FriendShipSearchResponseDto> memberSearch(@Valid

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -132,6 +132,13 @@ public class UserController {
     ) {
         return userService.registerEssential(loginUser, userRegisterEssentialDto);
     }
+    @GetMapping("/friendSearch/{keyword}")
+    public ApiResponseDto<List<UserSimpleDto>> searchUser(
+            String keyword
+    )
+    {
+        return userService.searchUser(keyword);
+    }
 
 //2
 }

--- a/src/main/java/com/PuzzleU/Server/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/controller/UserController.java
@@ -4,6 +4,7 @@ import com.PuzzleU.Server.common.ApiResponseDto;
 import com.PuzzleU.Server.common.ResponseUtils;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.experience.ExperienceDto;
+import com.PuzzleU.Server.dto.friendship.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.dto.relation.UserSkillsetRelationDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetListDto;
@@ -132,12 +133,16 @@ public class UserController {
     ) {
         return userService.registerEssential(loginUser, userRegisterEssentialDto);
     }
-    @GetMapping("/friendSearch/{keyword}")
-    public ApiResponseDto<List<UserSimpleDto>> searchUser(
-            String keyword
+    @GetMapping("/friendSearch")
+    public ApiResponseDto<FriendShipSearchResponseDto> searchUser(
+            @Valid
+            @RequestParam(value = "search", defaultValue = "None", required = false) String search,
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "id", required = false) String sortBy
     )
     {
-        return userService.searchUser(keyword);
+        return userService.searchUser(pageNo, pageSize, sortBy, search);
     }
 
 //2

--- a/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionSearchTotalDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/competition/CompetitionSearchTotalDto.java
@@ -1,0 +1,20 @@
+package com.PuzzleU.Server.dto.competition;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompetitionSearchTotalDto {
+    private List<CompetitionSearchDto> competitionSearchDtoList;
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+}

--- a/src/main/java/com/PuzzleU/Server/dto/friendship/FriendShipSearchResponseDto.java
+++ b/src/main/java/com/PuzzleU/Server/dto/friendship/FriendShipSearchResponseDto.java
@@ -16,5 +16,9 @@ public class FriendShipSearchResponseDto {
     // 유저의 이름, 한줄소개
     @JsonProperty("FriendList")
     private List<UserSimpleDto> userSimpleDtoList;
-
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
 }

--- a/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/CompetitionRepository.java
@@ -40,6 +40,6 @@ public interface CompetitionRepository extends JpaRepository<Competition, Long> 
     int updateVisit(@Param("id")Long id);
 
     @Query("SELECT c FROM Competition c WHERE c.competitionName LIKE %:keyword%")
-    List<Competition> findByCompetitionName(@Param("keyword") String keyword);
+    List<Competition> findByCompetitionName(@Param("keyword") String keyword, Pageable pageable);
 }
 

--- a/src/main/java/com/PuzzleU/Server/repository/FriendshipRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/FriendshipRepository.java
@@ -3,6 +3,8 @@ package com.PuzzleU.Server.repository;
 import com.PuzzleU.Server.entity.friendship.FriendShip;
 import com.PuzzleU.Server.entity.user.User;
 import feign.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,7 +16,7 @@ public interface FriendshipRepository extends JpaRepository<FriendShip, Long> {
 
 
     @Query("SELECT f FROM FriendShip f WHERE ((f.user1 = :user AND f.user2.userKoreaName LIKE %:keyword%) OR (f.user2 = :user AND f.user1.userKoreaName LIKE %:keyword%)) AND f.userStatus = true")
-    List<FriendShip> findActiveFriendshipsForUserAndKeyword(@Param("user") User user, @Param("keyword") String keyword);
+    Page<FriendShip> findActiveFriendshipsForUserAndKeyword(@Param("user") User user, @Param("keyword") String keyword, Pageable pageable);
 
 
 }

--- a/src/main/java/com/PuzzleU/Server/repository/UserRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.repository;
 
 import com.PuzzleU.Server.entity.user.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +9,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
-    List<User> findByUserKoreaNameContaining(String username);
+    List<User> findByUserKoreaNameContaining(String username, Pageable pageable);
 
 }

--- a/src/main/java/com/PuzzleU/Server/repository/UserRepository.java
+++ b/src/main/java/com/PuzzleU/Server/repository/UserRepository.java
@@ -3,9 +3,11 @@ package com.PuzzleU.Server.repository;
 import com.PuzzleU.Server.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+    List<User> findByUserKoreaNameContaining(String username);
 
 }

--- a/src/main/java/com/PuzzleU/Server/service/User/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/service/User/UserService.java
@@ -5,10 +5,7 @@ import com.PuzzleU.Server.common.ResponseUtils;
 import com.PuzzleU.Server.common.SuccessResponse;
 import com.PuzzleU.Server.dto.experience.ExperienceDto;
 import com.PuzzleU.Server.dto.skillset.SkillSetDto;
-import com.PuzzleU.Server.dto.user.LoginRequestsDto;
-import com.PuzzleU.Server.dto.user.SignupRequestDto;
-import com.PuzzleU.Server.dto.user.UserRegisterEssentialDto;
-import com.PuzzleU.Server.dto.user.UserRegisterOptionalDto;
+import com.PuzzleU.Server.dto.user.*;
 import com.PuzzleU.Server.entity.enumSet.Priority;
 import com.PuzzleU.Server.entity.experience.Experience;
 import com.PuzzleU.Server.entity.interest.Interest;
@@ -36,6 +33,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.print.DocFlavor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -277,6 +275,7 @@ public class UserService {
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 필수 정보 저장 완료"), null);
     }
-
-
+    public ApiResponseDto<List<UserSimpleDto>> searchUser(String keyword)
+    {
+        List<UserSimpleDto> userSimpleDtoList = userRepository.findByUserKoreaNameContaining(keyword);
 }

--- a/src/main/java/com/PuzzleU/Server/service/User/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/service/User/UserService.java
@@ -73,6 +73,7 @@ public class UserService {
     private final UserInterestRelationRepository userInterestRelationRepository;
     private final UserLocationRelationRepository userLocationRelationRepository;
 
+    // 회원가입 API
     @Transactional
     public ApiResponseDto<SuccessResponse> signup(SignupRequestDto requestDto) {
         String username = requestDto.getUsername();
@@ -108,6 +109,7 @@ public class UserService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "로그인 성공"),jwtToken);
 
     }
+    // 유저가 회원가입 후 옵션으로 선택해서 등록가능한 API
     public ApiResponseDto<SuccessResponse> createRegisterOptionalUser(
             UserDetails loginUser,
             UserRegisterOptionalDto userRegisterOptionalDto
@@ -189,6 +191,7 @@ public class UserService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "선택사항 저장완료"), null);
     }
 
+    // 회원가입 후 필수로 작성해야하는 것들을 등록하는 API
     public ApiResponseDto<SuccessResponse> registerEssential(UserDetails loginUser, UserRegisterEssentialDto userRegisterEssentialDto) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -281,6 +284,8 @@ public class UserService {
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 필수 정보 저장 완료"), null);
     }
+
+    // 모든 멤버들을 검색할 수 있는 API
     public ApiResponseDto<FriendShipSearchResponseDto> searchUser(int pageNo, int pageSize, String sortBy, String keyword)
     {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());

--- a/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/service/competition/CompetitionService.java
@@ -32,6 +32,7 @@ public class CompetitionService {
 
     private final Logger logger = LoggerFactory.getLogger(CompetitionService.class);
 
+    // 공모전 전체를 볼 수 있는 데이터를 넘기는 API
     @Transactional
     public ApiResponseDto<CompetitionHomeTotalDto> getHomepage(int pageNo, int pageSize, String sortBy, String keyword, CompetitionType type) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
@@ -85,6 +86,8 @@ public class CompetitionService {
 
         return ResponseUtils.ok(competitionHomeTotalDto, null);
     }
+
+    // 공모전 하나의 정보를 전체다 볼 수 있는 API
     @Transactional
     public ApiResponseDto<CompetitionSpecificDto> getSpecific (Long competitionId)
     {
@@ -115,7 +118,5 @@ public class CompetitionService {
         return ResponseUtils.ok(competitionSpecificDto, null);
     }
     // 최신순, 마감빠른순, 마감느린순, 인기순, 조회순, 팀빌딩순
-
-
 
 }

--- a/src/main/java/com/PuzzleU/Server/service/experience/ExperienceService.java
+++ b/src/main/java/com/PuzzleU/Server/service/experience/ExperienceService.java
@@ -28,6 +28,8 @@ public class ExperienceService {
     private final UserRepository userRepository;
 
 
+
+    // 유저의 경험을 생성하는 API
     public ApiResponseDto<SuccessResponse> createExperience(
             UserDetails loginUser,
             ExperienceDto experienceDto
@@ -49,6 +51,7 @@ public class ExperienceService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 저장완료"), null);
 
     }
+    // 유저의 경험을 수정하는 API
     public ApiResponseDto<SuccessResponse> updateExperience(
             UserDetails loginUser,
             Long experienceId,
@@ -99,6 +102,7 @@ public class ExperienceService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 수정완료"), null);
 
     }
+    // 유저의 경험을 삭제하는 API
     public ApiResponseDto<SuccessResponse> deleteExperience(
             UserDetails loginUser,Long experienceId
     )
@@ -113,6 +117,8 @@ public class ExperienceService {
         experienceRepository.delete(experience);
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 삭제완료"), null);
     }
+
+    // 유저가 자신의 페이지에서 자신의 경험리스트들을 확인가능한 API
     public ApiResponseDto<List<ExperienceDto>> getExperienceList(UserDetails loginUser) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -136,6 +142,7 @@ public class ExperienceService {
         return ResponseUtils.ok(experienceList, null);
 
     }
+    // 유저가 경험 리스트들중 하나를 클릭하면 자신의 세부적인 경험을 확인할 수 있는 API
     public ApiResponseDto<ExperienceDto> getExperience(UserDetails loginUser, Long experienceId) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));

--- a/src/main/java/com/PuzzleU/Server/service/skillset/SkillsetService.java
+++ b/src/main/java/com/PuzzleU/Server/service/skillset/SkillsetService.java
@@ -34,6 +34,8 @@ public class SkillsetService {
     private final UserRepository userRepository;
     private final SkillsetRepository skillsetRepository;
     private final UserSkillsetRelationRepository userSkillsetRelationRepository;
+
+    // 유저가 본인의 스킬셋을 등록가능한 API
     public ApiResponseDto<SuccessResponse> createSkillset(
             UserDetails loginUser, SkillSetListDto skillsetList
     )
@@ -60,6 +62,7 @@ public class SkillsetService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 저장완료"), null);
 
     }
+    // 유저가 자신의 스킬셋을 삭제가능함
     public ApiResponseDto<SuccessResponse> deleteSkillset(
             UserDetails loginUser, Long skillsetId
     )
@@ -80,6 +83,7 @@ public class SkillsetService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 삭제완료"), null);
 
     }
+    // 유저가 자신이 등록한 스킬셋의 리스트를 확인가능한 API
     public ApiResponseDto<List<UserSkillsetRelationDto>> getSkillsetList(UserDetails loginUser) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));

--- a/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
@@ -34,6 +34,7 @@ public class TeamService {
     private final FriendshipRepository friendshipRepository;
     private final LocationRepository locationRepository;
 
+    // 팀 구인글을 등록하는 API
     public ApiResponseDto<SuccessResponse> teamcreate(
             TeamCreateDto teamCreateDto
     )
@@ -50,6 +51,7 @@ public class TeamService {
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀구인글 생성완료"), null);
     }
+    // 공모전 팀 등록시 공모전검색을 해서 값을 가져오는 API
     @Transactional
     public ApiResponseDto<CompetitionSearchTotalDto> competitionTeamSearch(int pageNo, int pageSize, String sortBy, String keyword) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
@@ -73,9 +75,12 @@ public class TeamService {
 
         return ResponseUtils.ok(competitionSearchTotalDto, null);
     }
+
+
     // 유저 정보 리스트를 가져오고 여기에는 유저의 이름, id, 한줄소개가 있어야한다.
+    // 공모전글을 등록할때 내 친구들만 데이터를 가져오는 API
     @Transactional
-    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, UserDetails loginUser,int pageNo, int pageSize, String sortBy)
+    public ApiResponseDto<FriendShipSearchResponseDto> frIendRegister(String keyword, UserDetails loginUser,int pageNo, int pageSize, String sortBy)
     {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
         User user = userRepository.findByUsername(loginUser.getUsername())

--- a/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/service/team/TeamService.java
@@ -75,13 +75,17 @@ public class TeamService {
     }
     // 유저 정보 리스트를 가져오고 여기에는 유저의 이름, id, 한줄소개가 있어야한다.
     @Transactional
-    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, UserDetails loginUser)
+    public ApiResponseDto<FriendShipSearchResponseDto> firendRegister(String keyword, UserDetails loginUser,int pageNo, int pageSize, String sortBy)
     {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        Page<FriendShip> friendShips = friendshipRepository.findActiveFriendshipsForUserAndKeyword(user, keyword, pageable);
+        List<FriendShip> friendShipList = friendShips.getContent();
         FriendShipSearchResponseDto friendShipSearchResponseDto = new FriendShipSearchResponseDto();
         // 각각의 friendshipe에 대해서 user가 아닌 user에 대한 정보를 저장하고 리스트로 만들어준다
-        List<FriendShip> friendShipList = friendshipRepository.findActiveFriendshipsForUserAndKeyword(user, keyword);
+
         List<UserSimpleDto> userSimpleDtoList = new ArrayList<>();
         for(FriendShip friendShip:friendShipList)
         {
@@ -108,6 +112,7 @@ public class TeamService {
             }
         }
         friendShipSearchResponseDto.setUserSimpleDtoList(userSimpleDtoList);
+
      return ResponseUtils.ok(friendShipSearchResponseDto, null)  ;
     }
 }

--- a/src/main/java/com/PuzzleU/Server/service/university/UniversityService.java
+++ b/src/main/java/com/PuzzleU/Server/service/university/UniversityService.java
@@ -31,6 +31,7 @@ public class UniversityService {
     private final UniversityRepository universityRepository;
     private final MajorRepository majorRepository;
 
+    // 유저가 본인의 대학을 등록할 수 있는 API
     @Transactional
     public ApiResponseDto<SuccessResponse> createUniversity(
             UserDetails loginUser, UserUniversityDto userUniversityDto


### PR DESCRIPTION
## 공모전 구인글을 작성할때 공모전검색/친구검색 시 페이지네이션 적용 수정
기존의 모든 데이터를 뽑아주는 데이터에서 각각의 pageNo, Sortby, pageSize를 설정하여서 6개씩 주는 것으로 바꿨으며 모든데이터는 param으로 적용됩니다
## #76  팀원과 공모전을 각각 검색할때 페이지네이션이 가능하도록 작성하였습니다
    private List<UserSimpleDto> userSimpleDtoList;
    private int pageNo;
    private int pageSize;
    private long totalElements;
    private int totalPages;
    private boolean last;
    위와 같은 데이터들이 도출됩니다.

# 논의 해야하는 것
데이터들을 Getmapping 할때도 @sunghyun1356 은 ApiResponseDto에 넣어줘는데 @13155a1 은 바로 데이터를 전달해줌 -> 어떻게 할 건지 논의 해봐야함