### PR TITLE
[FEAT] #69 친구관계설정 구현 / 팀 구인글 생성

### DIFF
--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -30,7 +30,8 @@ public enum ErrorType {
     TOO_FEW_POSITIONS(400, "너무 적은 포지션이 입력되었습니다. 하나 이상의 포지션을 선택해야 합니다."),
     NAME_NOT_PROVIDED(400, "이름이 입력되지 않았습니다."),
     PUZZLE_ID_NOT_PROVIDED(400, "퍼즐 아이디가 입력되지 않았습니다."),
-    PROFILE_NOT_PROVIDED(400, "프로필이 입력되지 않았습니다.");
+    PROFILE_NOT_PROVIDED(400, "프로필이 입력되지 않았습니다."),
+    NOT_FOUND_FRIENDSHIP(400, "등록되지 않은 관계입니다.");
 
     private int code;
     private String message;

--- a/src/main/java/com/PuzzleU/Server/competition/repository/CompetitionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/competition/repository/CompetitionRepository.java
@@ -21,7 +21,6 @@ public interface CompetitionRepository extends JpaRepository<Competition, Long> 
     Page<Competition> findAll(@NonNull Pageable pageable);
     Page<Competition> findByCompetitionNameContaining(Pageable pageable,String keyword);
 
-
     @Query("SELECT c FROM Competition c LEFT JOIN FETCH c.competitionTypes WHERE c.competitionId = :id")
     Optional<Competition> findByCompetitionIdWithCompetitionTypes(@Param("id") Long id);
 

--- a/src/main/java/com/PuzzleU/Server/friendship/dto/FriendShipRegisterDto.java
+++ b/src/main/java/com/PuzzleU/Server/friendship/dto/FriendShipRegisterDto.java
@@ -1,0 +1,16 @@
+package com.PuzzleU.Server.friendship.dto;
+
+import com.PuzzleU.Server.user.entity.User;
+import lombok.*;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FriendShipRegisterDto {
+    private com.PuzzleU.Server.user.entity.User user1;
+    private User user2;
+    private Boolean status;
+}

--- a/src/main/java/com/PuzzleU/Server/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/PuzzleU/Server/friendship/repository/FriendshipRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FriendshipRepository extends JpaRepository<FriendShip, Long> {
 
@@ -16,5 +18,7 @@ public interface FriendshipRepository extends JpaRepository<FriendShip, Long> {
     @Query("SELECT f FROM FriendShip f WHERE ((f.user1 = :user AND f.user2.userKoreaName LIKE %:keyword%) OR (f.user2 = :user AND f.user1.userKoreaName LIKE %:keyword%)) AND f.userStatus = true")
     Page<FriendShip> findActiveFriendshipsForUserAndKeyword(@Param("user") User user, @Param("keyword") String keyword, Pageable pageable);
 
+    @Query("SELECT f FROM FriendShip f WHERE ((f.user1 = :user_first AND f.user2 = :user_second) OR (f.user1 = :user_second AND f.user2 = :user_first))")
+    Optional<FriendShip> findByUser1AndUser2(@Param("user_first") User user_first, @Param("user_second") User user_second);
 
 }

--- a/src/main/java/com/PuzzleU/Server/relations/entity/TeamLocationRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/TeamLocationRelation.java
@@ -3,18 +3,14 @@ package com.PuzzleU.Server.relations.entity;
 import com.PuzzleU.Server.location.entity.Location;
 import com.PuzzleU.Server.team.entity.Team;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "team_location_relation")
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-
+@Builder
 public class TeamLocationRelation {
 
     @Id

--- a/src/main/java/com/PuzzleU/Server/relations/entity/TeamUserRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/TeamUserRelation.java
@@ -3,11 +3,8 @@ package com.PuzzleU.Server.relations.entity;
 import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -15,6 +12,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 
 public class TeamUserRelation {
 

--- a/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
@@ -6,12 +6,15 @@ import com.PuzzleU.Server.competition.dto.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.team.dto.TeamCreateDto;
 import com.PuzzleU.Server.team.service.TeamService;
+import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,9 +23,13 @@ public class TeamController {
     private final UserService userService;
     private final TeamService teamService;
 
-    @PostMapping("/")
-    public ApiResponseDto<SuccessResponse> teamCreate(@Valid @RequestBody TeamCreateDto teamCreateDto) {
-        return teamService.teamcreate(teamCreateDto);
+    @PostMapping("")
+    public ApiResponseDto<SuccessResponse> teamCreate(@Valid @RequestBody TeamCreateDto teamCreateDto
+    ,@RequestParam Long competitionId,
+     @RequestParam List<Long> teamMember,
+     @AuthenticationPrincipal UserDetails loginUser,
+    @RequestParam List<Long> locations) {
+        return teamService.teamcreate(teamCreateDto, competitionId, teamMember,loginUser,locations);
     }
     @GetMapping("/searchCompetition")
     public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid
@@ -42,7 +49,7 @@ public class TeamController {
             @RequestParam(value = "sortBy", defaultValue = "friendshipId", required = false) String sortBy,
             @AuthenticationPrincipal UserDetails loginUser)
     {
-        return teamService.frIendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
+        return teamService.friendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/team/dto/TeamCreateDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/TeamCreateDto.java
@@ -2,7 +2,14 @@ package com.PuzzleU.Server.team.dto;
 
 import com.PuzzleU.Server.competition.entity.Competition;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class TeamCreateDto {
     private Competition competition;
     @Size(max = 30)
@@ -24,10 +31,6 @@ public class TeamCreateDto {
     private String teamContent;
 
     private Boolean teamStatus;
-
-
-
-
 
 }
 

--- a/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
@@ -6,13 +6,11 @@ import com.PuzzleU.Server.experience.dto.ExperienceDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.relations.dto.UserSkillsetRelationDto;
 import com.PuzzleU.Server.skillset.dto.SkillSetListDto;
-import com.PuzzleU.Server.dto.user.*;
 import com.PuzzleU.Server.experience.service.ExperienceService;
 import com.PuzzleU.Server.skillset.service.SkillsetService;
 import com.PuzzleU.Server.university.service.UniversityService;
 import com.PuzzleU.Server.user.dto.*;
 import com.PuzzleU.Server.user.service.UserService;
-import com.PuzzleU.Server.user.User.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -147,6 +145,29 @@ public class UserController {
     ) {
         return userService.updateUserProfileBasic(loginUser, userProfileBasicDto);
     }
+    @PostMapping("/friend/{friendId}/{userId}")
+    public ApiResponseDto<SuccessResponse> registerFriend(
+            @AuthenticationPrincipal UserDetails loginUser,
+            @PathVariable Long friendId)
+    {
+        return userService.registerFriend(loginUser, friendId);
+    }
+    @PatchMapping("/friend/{friendId}/{userId}")
+    public ApiResponseDto<SuccessResponse> responseFriend(
+            @AuthenticationPrincipal UserDetails loginUser,
+            @PathVariable Long friendId)
+    {
+        return userService.responseFriend(loginUser, friendId);
+    }
+    @DeleteMapping("/friend/{friendId}/{userId}")
+    public ApiResponseDto<SuccessResponse> deleteFriend(
+            @AuthenticationPrincipal UserDetails loginUser,
+            @PathVariable Long friendId)
+    {
+        return userService.deleteFriend(loginUser, friendId);
+    }
+
+
 
 }
 

--- a/src/main/java/com/PuzzleU/Server/user/service/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/user/service/UserService.java
@@ -1,11 +1,16 @@
 package com.PuzzleU.Server.user.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
+import com.PuzzleU.Server.common.enumSet.WorkType;
 import com.PuzzleU.Server.experience.dto.ExperienceDto;
 import com.PuzzleU.Server.experience.repository.ExperienceRepository;
+import com.PuzzleU.Server.friendship.dto.FriendShipRegisterDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
+import com.PuzzleU.Server.friendship.entity.FriendShip;
+import com.PuzzleU.Server.friendship.repository.FriendshipRepository;
 import com.PuzzleU.Server.position.repository.PositionRepository;
 import com.PuzzleU.Server.profile.repository.ProfileRepository;
 import com.PuzzleU.Server.relations.entity.UserInterestRelation;
@@ -15,8 +20,6 @@ import com.PuzzleU.Server.relations.repository.UserInterestRelationRepository;
 import com.PuzzleU.Server.relations.repository.UserLocationRelationRepository;
 import com.PuzzleU.Server.relations.repository.UserSkillsetRelationRepository;
 import com.PuzzleU.Server.skillset.dto.SkillSetDto;
-import com.PuzzleU.Server.dto.user.*;
-<<<<<<< HEAD:src/main/java/com/PuzzleU/Server/user/service/UserService.java
 import com.PuzzleU.Server.experience.entity.Experience;
 import com.PuzzleU.Server.interest.entity.Interest;
 import com.PuzzleU.Server.location.entity.Location;
@@ -30,7 +33,6 @@ import com.PuzzleU.Server.university.entity.University;
 import com.PuzzleU.Server.interest.repository.InterestRepository;
 import com.PuzzleU.Server.location.repository.LocationRepository;
 import com.PuzzleU.Server.university.repository.UniversityRepository;
-import com.PuzzleU.Server.user.User.dto.*;
 import com.PuzzleU.Server.common.enumSet.ErrorType;
 import com.PuzzleU.Server.common.enumSet.UserRoleEnum;
 import com.PuzzleU.Server.common.exception.RestApiException;
@@ -38,28 +40,7 @@ import com.PuzzleU.Server.common.jwt.JwtUtil;
 import com.PuzzleU.Server.user.dto.*;
 import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.repository.UserRepository;
-=======
-import com.PuzzleU.Server.entity.competition.Competition;
-import com.PuzzleU.Server.entity.enumSet.Priority;
-import com.PuzzleU.Server.entity.enumSet.WorkType;
-import com.PuzzleU.Server.entity.experience.Experience;
-import com.PuzzleU.Server.entity.interest.Interest;
-import com.PuzzleU.Server.entity.location.Location;
-import com.PuzzleU.Server.entity.major.Major;
-import com.PuzzleU.Server.entity.position.Position;
-import com.PuzzleU.Server.entity.profile.Profile;
-import com.PuzzleU.Server.entity.relations.UserInterestRelation;
-import com.PuzzleU.Server.entity.relations.UserLocationRelation;
-import com.PuzzleU.Server.entity.relations.UserSkillsetRelation;
-import com.PuzzleU.Server.entity.skillset.Skillset;
-import com.PuzzleU.Server.entity.university.University;
-import com.PuzzleU.Server.entity.user.User;
-import com.PuzzleU.Server.entity.enumSet.ErrorType;
-import com.PuzzleU.Server.entity.enumSet.UserRoleEnum;
-import com.PuzzleU.Server.exception.RestApiException;
-import com.PuzzleU.Server.jwt.JwtUtil;
-import com.PuzzleU.Server.repository.*;
->>>>>>> 7452986701446d42244b9cb0453c17e303d5d995:src/main/java/com/PuzzleU/Server/service/User/UserService.java
+
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -70,11 +51,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-<<<<<<< HEAD:src/main/java/com/PuzzleU/Server/user/service/UserService.java
-=======
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
->>>>>>> 7452986701446d42244b9cb0453c17e303d5d995:src/main/java/com/PuzzleU/Server/service/User/UserService.java
 
 import java.util.ArrayList;
 import java.util.List;
@@ -109,6 +87,7 @@ public class UserService {
     private final LocationRepository locationRepository;
     private final UserInterestRelationRepository userInterestRelationRepository;
     private final UserLocationRelationRepository userLocationRelationRepository;
+    private final FriendshipRepository friendshipRepository;
 
     // 회원가입 API
     @Transactional
@@ -128,6 +107,7 @@ public class UserService {
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 성공"), null);
     }
+
     @org.springframework.transaction.annotation.Transactional(readOnly = true)
     public ApiResponseDto<SuccessResponse> login(LoginRequestsDto requestDto, HttpServletResponse response) {
         String username = requestDto.getUsername();
@@ -143,9 +123,10 @@ public class UserService {
         response.setHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.get().getUsername(), user.get().getRole()));
         String jwtToken = jwtUtil.createToken(user.get().getUsername(), user.get().getRole());
         jwtToken.substring(7);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "로그인 성공"),jwtToken);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "로그인 성공"), jwtToken);
 
     }
+
     // 유저가 회원가입 후 옵션으로 선택해서 등록가능한 API
     public ApiResponseDto<SuccessResponse> createRegisterOptionalUser(
             UserDetails loginUser,
@@ -155,8 +136,7 @@ public class UserService {
 
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
-        if(userRegisterOptionalDto.getUniversityStart() == null)
-        {
+        if (userRegisterOptionalDto.getUniversityStart() == null) {
             System.out.println("null");
         }
         Optional<Major> optionalMajor = majorRepository.findById(userRegisterOptionalDto.getMajorId());
@@ -164,7 +144,6 @@ public class UserService {
         System.out.println(userRegisterOptionalDto.getMajorId());
         Optional<University> optionalUniversity = universityRepository.findById(userRegisterOptionalDto.getUniversityId());
         System.out.println(optionalUniversity);
-
 
 
         Major major = optionalMajor.orElseThrow(() -> {
@@ -253,7 +232,7 @@ public class UserService {
             throw new RestApiException(ErrorType.PROFILE_NOT_PROVIDED);
         }
         Profile profile = profileRepository.findByProfileId(profileId)
-                        .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_PROFILE));
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_PROFILE));
         user.setUserProfile(profile);
 
         // 포지션 설정
@@ -264,7 +243,7 @@ public class UserService {
             throw new RestApiException(ErrorType.TOO_FEW_POSITIONS);
         }
         Position position1 = positionRepository.findByPositionId(positionId1)
-                        .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_POSITION));
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_POSITION));
         user.setUserPosition1(position1);
 
         if (positionId2 != null) { // 2순위까지 골랐을 때
@@ -277,11 +256,11 @@ public class UserService {
 
 
         // 관심 분야 설정
-        for (Long interestId: userRegisterEssentialDto.getUserInterestIdList()) {
+        for (Long interestId : userRegisterEssentialDto.getUserInterestIdList()) {
             Interest interest = interestRepository.findByInterestId(interestId)
                     .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_INTEREST));
             Boolean interestPass = Boolean.FALSE;
-            for (UserInterestRelation userInterestRelation: user.getUserInterestRelations()) {
+            for (UserInterestRelation userInterestRelation : user.getUserInterestRelations()) {
                 if (userInterestRelation.getInterest() == interest) {
                     interestPass = Boolean.TRUE; // 이미 있는 관계면 저장하지 않음
                 }
@@ -300,12 +279,12 @@ public class UserService {
             throw new RestApiException(ErrorType.TOO_MUCH_LOCATIONS);
         }
 
-        for (Long locationId: userRegisterEssentialDto.getUserLocationIdList()) {
+        for (Long locationId : userRegisterEssentialDto.getUserLocationIdList()) {
             Location location = locationRepository.findByLocationId(locationId)
                     .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_LOCATION));
 
             Boolean locationPass = Boolean.FALSE;
-            for (UserLocationRelation userLocationRelation: user.getUserLocationRelations()) {
+            for (UserLocationRelation userLocationRelation : user.getUserLocationRelations()) {
                 if (userLocationRelation.getLocation() == location) {
                     locationPass = Boolean.TRUE; // 이미 있는 연관 관계면 저장하지 않음
                 }
@@ -323,8 +302,7 @@ public class UserService {
     }
 
     // 모든 멤버들을 검색할 수 있는 API
-    public ApiResponseDto<FriendShipSearchResponseDto> searchUser(int pageNo, int pageSize, String sortBy, String keyword)
-    {
+    public ApiResponseDto<FriendShipSearchResponseDto> searchUser(int pageNo, int pageSize, String sortBy, String keyword) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
         Page<User> users;
         users = new PageImpl<>(userRepository.findByUserKoreaNameContaining(keyword, pageable));
@@ -347,7 +325,7 @@ public class UserService {
         friendShipSearchResponseDto.setTotalElements(users.getTotalElements());
         return ResponseUtils.ok(friendShipSearchResponseDto, null);
     }
-  
+
     public ApiResponseDto<SuccessResponse> updateUserProfileBasic(UserDetails loginUser, UserProfileBasicDto userProfileBasicDto) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -393,4 +371,51 @@ public class UserService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "프로필 기본 정보 수정 완료"), null);
     }
 
+    // 특정 유저에게 친구신청을 거는 것
+    public ApiResponseDto<SuccessResponse> registerFriend(UserDetails loginUser, Long userId) {
+        User user1 = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        // friendship이 만들어져야한다
+        // 무조건 거는 사람이 user1, 받는 사람이 user2로 되도록
+        Optional<User> userOptional = userRepository.findById(userId);
+        User user2 = userOptional.orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        // 만약에 user1과 2가 존재한다면 끝
+        Optional<FriendShip> friendShip_check = friendshipRepository.findByUser1AndUser2(user1, user2);
+
+        if (friendShip_check.isPresent()) {
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "이미 진행된 친구신청입니다."), null);
+        } else {
+            // 친구 관계가 존재하지 않는 경우, 새로운 친구 관계 생성
+            FriendShip friendShip = new FriendShip();
+            friendShip.setUser2(user2);
+            friendShip.setUser1(user1);
+            friendShip.setUserStatus(false);
+            friendshipRepository.save(friendShip);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), null);
+        }
+
+    }
+    public ApiResponseDto<SuccessResponse> responseFriend(UserDetails loginUser, Long userId) {
+        User user1 = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<User> userOptional = userRepository.findById(userId);
+        User user2 = userOptional.orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<FriendShip> friendShip_check = friendshipRepository.findByUser1AndUser2(user1, user2);
+        FriendShip friendShip = friendShip_check.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_FRIENDSHIP));
+        friendShip.setUserStatus(true);
+        friendshipRepository.save(friendShip);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), null);
+
+    }
+    public ApiResponseDto<SuccessResponse> deleteFriend(UserDetails loginUser, Long userId) {
+        User user1 = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<User> userOptional = userRepository.findById(userId);
+        User user2 = userOptional.orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<FriendShip> friendShip_check = friendshipRepository.findByUser1AndUser2(user1, user2);
+        FriendShip friendShip = friendShip_check.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_FRIENDSHIP));
+        friendshipRepository.delete(friendShip);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), null);
+
+    }
 }


### PR DESCRIPTION
#69 
## 친구추가 및 친구 친구추가 상태 응답과 삭제
친구추가를 걸때 friendship을 생성하고, 그 생성에 대한 응답을 받으면 status가 true로 변경되고, 만약에 친구요청을 취소하거나 친구 상태를 끊을떄 friendship을 삭제 하도록 해주었습니다.
@Jquery를 사용할 때 user1, user2에 입력되는 값의 순서는 상관 없도록 하였습니다.

#68 
## 모집 글 만들기
로그인을 하여서 팀구인글을 작성하는 유저의 정보가 담긴 Teamuserreltation의 iswriter는 true로 되도록 수정하였으며
team멤버와 location은 param으로, 글 내용등은 body로 받도록 작성하였습니다.