### PR TITLE
[FEAT] #68 TEAM UPDATE/DELETE

### DIFF
--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -31,8 +31,9 @@ public enum ErrorType {
     NAME_NOT_PROVIDED(400, "이름이 입력되지 않았습니다."),
     PUZZLE_ID_NOT_PROVIDED(400, "퍼즐 아이디가 입력되지 않았습니다."),
     PROFILE_NOT_PROVIDED(400, "프로필이 입력되지 않았습니다."),
-    NOT_FOUND_FRIENDSHIP(400, "등록되지 않은 관계입니다.");
-
+    NOT_FOUND_FRIENDSHIP(400, "등록되지 않은 관계입니다."),
+    NOT_FOUND_TEAM(400, "팀을 찾을 수 없습니다"),
+    NOT_FOUND_RELATION(400, "올바르지 않은 관계입니다");
     private int code;
     private String message;
 

--- a/src/main/java/com/PuzzleU/Server/position/entity/Position.java
+++ b/src/main/java/com/PuzzleU/Server/position/entity/Position.java
@@ -1,5 +1,6 @@
 package com.PuzzleU.Server.position.entity;
 
+import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -29,4 +30,8 @@ public class Position {
 
     @OneToMany(mappedBy = "userPosition2")
     private List<User> userList2 = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team")
+    private Team team;
 }

--- a/src/main/java/com/PuzzleU/Server/relations/repository/TeamUserRepository.java
+++ b/src/main/java/com/PuzzleU/Server/relations/repository/TeamUserRepository.java
@@ -1,9 +1,25 @@
 package com.PuzzleU.Server.relations.repository;
 
+import com.PuzzleU.Server.friendship.entity.FriendShip;
 import com.PuzzleU.Server.relations.entity.TeamUserRelation;
+import com.PuzzleU.Server.team.entity.Team;
+import com.PuzzleU.Server.user.entity.User;
+import feign.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TeamUserRepository extends JpaRepository<TeamUserRelation, Long> {
+    @Query("SELECT f FROM TeamUserRelation  f WHERE (f.user = :user AND f.team =:team)")
+    Optional<TeamUserRelation> findByUserAndTeam(@Param("user")User user, @Param("team") Team team);
+
+
+    List<TeamUserRelation> findByTeam(Team team);
+
 }

--- a/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
@@ -28,8 +28,26 @@ public class TeamController {
     ,@RequestParam Long competitionId,
      @RequestParam List<Long> teamMember,
      @AuthenticationPrincipal UserDetails loginUser,
+    @RequestParam List<Long> positions,
     @RequestParam List<Long> locations) {
-        return teamService.teamcreate(teamCreateDto, competitionId, teamMember,loginUser,locations);
+        return teamService.teamcreate(teamCreateDto, competitionId, teamMember,loginUser,locations, positions);
+    }
+    @PatchMapping("/{teamId}")
+    public ApiResponseDto<SuccessResponse> teamUpdate(@Valid @RequestBody TeamCreateDto teamCreateDto
+            ,@RequestParam Long competitionId,
+            @RequestParam List<Long> teamMember,
+            @AuthenticationPrincipal UserDetails loginUser,
+            @RequestParam List<Long> locations,
+            @RequestParam List<Long> positions,
+            @PathVariable Long teamId) {
+        return teamService.teamUpdate(teamCreateDto, competitionId, teamMember,loginUser,locations, positions, teamId);
+    }
+    @DeleteMapping("/{teamId}")
+    public ApiResponseDto<SuccessResponse> teamDelete(@Valid
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal UserDetails loginUser
+            ) {
+        return teamService.teamdelete(teamId,loginUser);
     }
     @GetMapping("/searchCompetition")
     public ApiResponseDto<CompetitionSearchTotalDto> competitionSearch(@Valid

--- a/src/main/java/com/PuzzleU/Server/team/entity/Team.java
+++ b/src/main/java/com/PuzzleU/Server/team/entity/Team.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.team.entity;
 import com.PuzzleU.Server.common.enumSet.BaseEntity;
 import com.PuzzleU.Server.apply.entity.Apply;
 import com.PuzzleU.Server.competition.entity.Competition;
+import com.PuzzleU.Server.position.entity.Position;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -51,7 +52,9 @@ public class Team extends BaseEntity {
     @JoinColumn(name = "competition_id")
     private Competition competition;
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
     private List<Apply> applyList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
+    private List<Position> positionList = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.team.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.competition.repository.CompetitionRepository;
@@ -9,6 +10,8 @@ import com.PuzzleU.Server.competition.dto.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.location.entity.Location;
 import com.PuzzleU.Server.location.repository.LocationRepository;
+import com.PuzzleU.Server.position.entity.Position;
+import com.PuzzleU.Server.position.repository.PositionRepository;
 import com.PuzzleU.Server.relations.entity.TeamLocationRelation;
 import com.PuzzleU.Server.relations.entity.TeamUserRelation;
 import com.PuzzleU.Server.relations.repository.TeamLocationRelationRepository;
@@ -45,6 +48,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamUserRepository teamUserRepository;
     private final TeamLocationRelationRepository teamLocationRelationRepository;
+    private final PositionRepository positionRepository;
 
     // 팀 구인글을 등록하는 API
     @Transactional
@@ -53,15 +57,24 @@ public class TeamService {
             Long competitionId,
             List<Long> teamMember,
             UserDetails loginUser
-            ,List<Long> locations
+            ,List<Long> locations,
+            List<Long> positions
     )
     {
+
         User loginuser = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Competition> competitionOptional = competitionRepository.findById(competitionId);
         Competition competition = competitionOptional.orElseThrow(
                 ()-> new RestApiException(ErrorType.NOT_FOUND_COMPETITION)
         );
+        List<Position>positionList = new ArrayList<>();
+        for(Long positionId : positions)
+        {
+            Optional<Position> positionOptional = positionRepository.findById(positionId);
+            Position position = positionOptional.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_POSITION));
+            positionList.add(position);
+        }
         Team team = new Team();
         team.setTeamTitle(teamCreateDto.getTeamTitle());
         team.setTeamMemberNeed(teamCreateDto.getTeamMemberNeed());
@@ -71,7 +84,8 @@ public class TeamService {
         team.setTeamContent(teamCreateDto.getTeamContent());
         team.setTeamStatus(teamCreateDto.getTeamStatus());
         team.setCompetition(competition);
-        team.setTeamMemberNow(teamMember.size());
+        team.setTeamMemberNow(teamMember.size()+1);
+        team.setPositionList(positionList);
         teamRepository.save(team);
         TeamUserRelation teamUserRelationWriter=  TeamUserRelation.builder()
                 .team(team)
@@ -103,13 +117,128 @@ public class TeamService {
                     .location(location)
                     .build();
             teamLocationRelationRepository.saveAndFlush(teamLocationRelation);
-
         }
 
 
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 생성완료"), null);
     }
+    public ApiResponseDto<SuccessResponse> teamUpdate(TeamCreateDto teamCreateDto, Long competitionId,
+                                                      List<Long> teamMember, UserDetails loginUser,
+                                                      List<Long> locations, List<Long> positions, Long teamId) {
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        Competition competition = competitionRepository.findById(competitionId)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COMPETITION));
+
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_TEAM));
+
+        TeamUserRelation teamUserRelation = teamUserRepository.findByUserAndTeam(user, team)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_RELATION));
+
+        if (teamUserRelation.getIsWriter()) {
+            List<Position> positionList = new ArrayList<>();
+            for (Long positionId : positions) {
+                Position position = positionRepository.findById(positionId)
+                        .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_POSITION));
+                positionList.add(position);
+            }
+
+            team.setTeamTitle(teamCreateDto.getTeamTitle());
+            team.setTeamMemberNeed(teamCreateDto.getTeamMemberNeed());
+            team.setTeamUntact(teamCreateDto.getTeamUntact());
+            team.setTeamUrl(teamCreateDto.getTeamUrl());
+            team.setTeamIntroduce(teamCreateDto.getTeamIntroduce());
+            team.setTeamContent(teamCreateDto.getTeamContent());
+            team.setTeamStatus(teamCreateDto.getTeamStatus());
+            team.setCompetition(competition);
+            team.setTeamMemberNow(teamMember.size()+1);
+            team.setPositionList(positionList);
+            teamRepository.save(team);
+
+            List<TeamUserRelation> existingRelations = teamUserRepository.findByTeam(team);
+
+            for (Long userId : teamMember) {
+                User memberUser = userRepository.findById(userId)
+                        .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+                TeamUserRelation newRelation = TeamUserRelation.builder()
+                        .team(team)
+                        .user(memberUser)
+                        .isWriter(false)
+                        .build();
+
+                boolean relationExists = existingRelations.stream()
+                        .anyMatch(relation -> relation.getUser().getId().equals(userId));
+
+                if (!relationExists) {
+                    teamUserRepository.saveAndFlush(newRelation);
+                }
+            }
+
+            existingRelations.forEach(existingRelation -> {
+                Long existingUserId = existingRelation.getUser().getId();
+                if (!teamMember.contains(existingUserId)) {
+                    teamUserRepository.delete(existingRelation);
+                }
+            });
+
+            for (Long locationId : locations) {
+                Location location = locationRepository.findById(locationId)
+                        .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_LOCATION));
+                TeamLocationRelation teamLocationRelation = TeamLocationRelation.builder()
+                        .team(team)
+                        .location(location)
+                        .build();
+                teamLocationRelationRepository.saveAndFlush(teamLocationRelation);
+            }
+            TeamUserRelation teamUserRelation1 = new TeamUserRelation();
+            teamUserRelation1.setUser(user);
+            teamUserRelation1.setTeam(team);
+            teamUserRelation1.setIsWriter(true);
+            teamUserRepository.save(teamUserRelation1);
+
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 수정완료"), null);
+        } else {
+            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, "유저의 권한이 없습니다."));
+        }
+    }
+    public ApiResponseDto<SuccessResponse> teamdelete(
+            Long teamId,
+            UserDetails loginUser
+    )
+    {
+        System.out.println(loginUser);
+        User user = userRepository.findByUsername(loginUser.getUsername()).orElseThrow(
+                ()-> new RestApiException(ErrorType.NOT_FOUND_USER)
+        );
+        Optional<Team>teamOptional = teamRepository.findById(teamId);
+        Team team = teamOptional.orElseThrow(()->
+                new RestApiException(ErrorType.NOT_FOUND_TEAM));
+
+        Optional<TeamUserRelation> teamUserRelationOptional = teamUserRepository.findByUserAndTeam(user, team);
+        if(teamUserRelationOptional.isPresent())
+        {
+            TeamUserRelation teamUserRelation = teamUserRelationOptional.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_RELATION));
+            if (teamUserRelation.getIsWriter())
+            {
+                teamRepository.delete(team);
+
+            }
+            else{
+                return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE,"유저의 권한이 없습니다."));
+            }
+        }
+        else{
+            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_FOUND,"유저가 속한 팀이 아닙니다."));
+        }
+
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 삭제완료"), null);
+
+    }
+
     // 공모전 팀 등록시 공모전검색을 해서 값을 가져오는 API
     @Transactional
     public ApiResponseDto<CompetitionSearchTotalDto> competitionTeamSearch(int pageNo, int pageSize, String sortBy, String keyword) {


### PR DESCRIPTION
## 팀 업데이트 작성
팀 멤버, 포지션 등등 모두다 변경가능하도록 하였습니다.
## 팀 삭제 작성
팀 삭제시 모든 관계가 삭제되도록 하였습니다


#참고
@13155a1 
카카오 로그인시, 리프레시 토큰이 안보이는데 알려주세욤 ㅠㅠㅠㅠ 테스트를 못하고 있슴돠
