### PR TITLE
[FEAT] #89 Team 검색 기능 구현

### DIFF
--- a/src/main/java/com/PuzzleU/Server/apply/entity/Apply.java
+++ b/src/main/java/com/PuzzleU/Server/apply/entity/Apply.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.apply.entity;
 
 import com.PuzzleU.Server.common.enumSet.ApplyStatus;
 import com.PuzzleU.Server.team.entity.Team;
+import com.PuzzleU.Server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,4 +34,8 @@ public class Apply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user")
+    private User user;
 }

--- a/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
@@ -1,9 +1,17 @@
 package com.PuzzleU.Server.apply.repository;
 
 import com.PuzzleU.Server.apply.entity.Apply;
+import com.PuzzleU.Server.team.entity.Team;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Repository;
+
+import java.awt.print.Pageable;
+import java.util.List;
 
 @Repository
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
+    List<Apply> findByTeam(Team team, Pageable pageable);
 }

--- a/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
@@ -2,10 +2,11 @@ package com.PuzzleU.Server.apply.repository;
 
 import com.PuzzleU.Server.apply.entity.Apply;
 import com.PuzzleU.Server.team.entity.Team;
+import com.PuzzleU.Server.user.entity.User;
 import feign.Param;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Repository;
 
 import java.awt.print.Pageable;
@@ -13,5 +14,18 @@ import java.util.List;
 
 @Repository
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
-    List<Apply> findByTeam(Team team, Pageable pageable);
+
+    @Query("SELECT a.team FROM Apply a WHERE a.user = :user")
+    List<Team> findByUser(User user, org.springframework.data.domain.Pageable pageable);
+    @Query("SELECT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'WAITING'")
+    List<Team> findByUserAndApplyStatusIsWaiting(User user, org.springframework.data.domain.Pageable pageable);
+    @Query("SELECT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'FINISHED'")
+    List<Team> findByUserAndApplyStatusIsFinished(User user, org.springframework.data.domain.Pageable pageable);
+
+    @Query("SELECT DISTINCT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'WAITING'")
+    List<Team> findFirstByUserAndApplyStatusIsWaitingOne(User user);
+
+    @Query("SELECT DISTINCT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'FINISHED'")
+    List<Team> findFirstByUserAndApplyStatusIsFinishedOne(User user);
+
 }

--- a/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
+++ b/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
@@ -33,7 +33,8 @@ public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
 
-    private static final long TOKEN_TIME = 60 * 60 * 1000L;
+    // 60 더 곱했습니다
+    private static final long TOKEN_TIME = 60*60 * 60 * 1000L;
 
     @Value("${jwt.secret.key}")
     private String secretKey;

--- a/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
@@ -6,6 +6,7 @@ import com.PuzzleU.Server.competition.dto.CompetitionSpecificDto;
 import com.PuzzleU.Server.common.enumSet.CompetitionType;
 import com.PuzzleU.Server.competition.service.CompetitionService;
 import com.PuzzleU.Server.team.dto.TeamListDto;
+import com.PuzzleU.Server.team.dto.TeamSpecificDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -41,6 +42,11 @@ public class CompetitionController {
     @RequestParam(value = "sortBy", defaultValue = "teamId", required = false) String sortBy)
     {
         return competitionService.getTeamList(competition_id, pageNo, pageSize, sortBy);
+    }
+    @GetMapping("/homepage/{competition_id}/team/{team_id}")
+    public ApiResponseDto<TeamSpecificDto> teamSpecific(@Valid @PathVariable Long competition_id, @PathVariable Long team_id)
+    {
+        return competitionService.getTeamSpecific(competition_id, team_id);
     }
 
 

--- a/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
@@ -48,6 +48,15 @@ public class CompetitionController {
     {
         return competitionService.getTeamSpecific(competition_id, team_id);
     }
+    @GetMapping("/homepage/team")
+    public ApiResponseDto<TeamListDto> teamSearch(@Valid
+                                                  @RequestParam(value = "search", defaultValue = "None", required = false) String search,
+                                                  @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+                                                @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+                                                @RequestParam(value = "sortBy", defaultValue = "teamId", required = false) String sortBy)
+    {
+        return competitionService.getTeamSearchList(pageNo, pageSize, sortBy,search);
+    }
 
 
 }

--- a/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
@@ -167,6 +167,7 @@ public class CompetitionService {
                         String location = teamLocationRelation1.getLocation().getLocationName();
                         locationList.add(location);
                     }
+                    teamAbstractDto.setTeamId(team.getTeamId());
 
                     teamAbstractDto.setTeamNeed(team.getTeamMemberNeed());
                     teamAbstractDto.setTeamNowMember(team.getTeamMemberNow());
@@ -278,7 +279,7 @@ public class CompetitionService {
                         String location = teamLocationRelation1.getLocation().getLocationName();
                         locationList.add(location);
                     }
-
+                    teamAbstractDto.setTeamId(team.getTeamId());
                     teamAbstractDto.setTeamNeed(team.getTeamMemberNeed());
                     teamAbstractDto.setTeamNowMember(team.getTeamMemberNow());
                     teamAbstractDto.setTeamTitle(team.getTeamTitle());

--- a/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
@@ -184,6 +184,7 @@ public class CompetitionService {
                     return teamAbstractDto;
                 })
                 .collect(Collectors.toList());
+        teamListDto.setTotalTeam(teamAbstractDtos.size());
         teamListDto.setTeamList(teamAbstractDtos);
         teamListDto.setLast(teamPage.isLast());
         teamListDto.setTotalPages(teamPage.getTotalPages());

--- a/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
@@ -157,8 +157,6 @@ public class CompetitionService {
                     for (TeamUserRelation teamuserRelation : teamUserRelation) {
                         if (teamuserRelation.getIsWriter())
                         {
-                            System.out.println(teamuserRelation.getIsWriter());
-                            System.out.println(teamuserRelation.getUser().getUserKoreaName());
                             teamAbstractDto.setTeamWriter(teamuserRelation.getUser().getUserKoreaName());
                             break;
                         }

--- a/src/main/java/com/PuzzleU/Server/team/dto/ApplyTeamDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/ApplyTeamDto.java
@@ -1,0 +1,17 @@
+package com.PuzzleU.Server.team.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApplyTeamDto {
+    @JsonProperty("WAITING")
+    private TeamAbstractDto teamListDto1;
+    @JsonProperty("FINISHED")
+    private TeamAbstractDto teamListDto2;
+}

--- a/src/main/java/com/PuzzleU/Server/team/dto/TeamAbstractDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/TeamAbstractDto.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Builder
 public class TeamAbstractDto {
 
+    private Long teamId;
     private String teamTitle;
     private String teamWriter;
     private List<String> positionList;

--- a/src/main/java/com/PuzzleU/Server/team/dto/TeamSpecificDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/TeamSpecificDto.java
@@ -1,0 +1,27 @@
+package com.PuzzleU.Server.team.dto;
+
+import com.PuzzleU.Server.user.dto.UserSimpleDto;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamSpecificDto {
+    private String teamTitle;
+    private String teamWriter;
+    private List<String> positionList;
+    private Integer teamNowMember;
+    private Integer teamNeed;
+    private Boolean teamUntact;
+    private List<String> teamLocations;
+    private String teamPoster;
+    private List<UserSimpleDto> members;
+    private String teamIntroduce;
+    private String teamContent;
+
+}

--- a/src/main/java/com/PuzzleU/Server/team/repository/TeamRepository.java
+++ b/src/main/java/com/PuzzleU/Server/team/repository/TeamRepository.java
@@ -15,4 +15,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t WHERE t.competition =:competition")
     List<Team> findByCompetition(@Param("competition") Competition competition, Pageable pageable);
+
+    List<Team> findByTeamTitleContaining(String search, Pageable pageable);
 }

--- a/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.PuzzleU.Server.relations.dto.UserSkillsetRelationDto;
 import com.PuzzleU.Server.skillset.dto.SkillSetListDto;
 import com.PuzzleU.Server.experience.service.ExperienceService;
 import com.PuzzleU.Server.skillset.service.SkillsetService;
+import com.PuzzleU.Server.team.dto.TeamListDto;
 import com.PuzzleU.Server.university.service.UniversityService;
 import com.PuzzleU.Server.user.dto.*;
 import com.PuzzleU.Server.user.service.UserService;
@@ -165,6 +166,18 @@ public class UserController {
             @PathVariable Long friendId)
     {
         return userService.deleteFriend(loginUser, friendId);
+    }
+    @GetMapping("/apply")
+    public ApiResponseDto<TeamListDto> getApply(
+            @Valid
+            @AuthenticationPrincipal UserDetails loginUser,
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "teamid", required = false) String sortBy,
+            @RequestParam(value = "type", defaultValue = "total", required = false) String type
+    )
+    {
+        return userService.getApply(loginUser,pageNo,pageSize,sortBy,type);
     }
 
 

--- a/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.PuzzleU.Server.relations.dto.UserSkillsetRelationDto;
 import com.PuzzleU.Server.skillset.dto.SkillSetListDto;
 import com.PuzzleU.Server.experience.service.ExperienceService;
 import com.PuzzleU.Server.skillset.service.SkillsetService;
+import com.PuzzleU.Server.team.dto.ApplyTeamDto;
 import com.PuzzleU.Server.team.dto.TeamListDto;
 import com.PuzzleU.Server.university.service.UniversityService;
 import com.PuzzleU.Server.user.dto.*;
@@ -168,16 +169,24 @@ public class UserController {
         return userService.deleteFriend(loginUser, friendId);
     }
     @GetMapping("/apply")
-    public ApiResponseDto<TeamListDto> getApply(
+    public ApiResponseDto<ApplyTeamDto> getApply(
+            @Valid
+            @AuthenticationPrincipal UserDetails loginUser
+    )
+    {
+        return userService.getApply(loginUser);
+    }
+    @GetMapping("/apply/{type}")
+    public ApiResponseDto<TeamListDto> getApplyType(
             @Valid
             @AuthenticationPrincipal UserDetails loginUser,
             @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
             @RequestParam(value = "pageSize", defaultValue = "6", required = false) int pageSize,
-            @RequestParam(value = "sortBy", defaultValue = "teamid", required = false) String sortBy,
-            @RequestParam(value = "type", defaultValue = "total", required = false) String type
+            @RequestParam(value = "sortBy", defaultValue = "applyid", required = false) String sortBy,
+            @PathVariable(value = "type",required = false) String type
     )
     {
-        return userService.getApply(loginUser,pageNo,pageSize,sortBy,type);
+        return userService.getApplyType(loginUser,pageNo,pageSize,sortBy,type);
     }
 
 

--- a/src/main/java/com/PuzzleU/Server/user/entity/User.java
+++ b/src/main/java/com/PuzzleU/Server/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.PuzzleU.Server.user.entity;
 
+import com.PuzzleU.Server.apply.entity.Apply;
 import com.PuzzleU.Server.common.enumSet.UniversityStatus;
 import com.PuzzleU.Server.common.enumSet.UserRoleEnum;
 import com.PuzzleU.Server.common.enumSet.WorkType;
@@ -101,7 +102,7 @@ public class User {
     @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserSkillsetRelation> userSkillsetRelations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<Experience> experience = new ArrayList<>();
 
     @OneToMany(mappedBy = "user1",cascade = CascadeType.REMOVE)
@@ -110,9 +111,11 @@ public class User {
     @OneToMany(mappedBy = "user2",cascade = CascadeType.REMOVE)
     private List<FriendShip> friendShip2 = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<Heart> hearts = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Apply> applies = new ArrayList<>();
     @Builder
     public User(
             Long id,

--- a/src/main/java/com/PuzzleU/Server/user/service/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/user/service/UserService.java
@@ -453,7 +453,7 @@ public class UserService {
                         String location = teamLocationRelation1.getLocation().getLocationName();
                         locationList.add(location);
                     }
-
+                    teamAbstractDto.setTeamId(team.getTeamId());
                     teamAbstractDto.setTeamNeed(team.getTeamMemberNeed());
                     teamAbstractDto.setTeamNowMember(team.getTeamMemberNow());
                     teamAbstractDto.setTeamTitle(team.getTeamTitle());
@@ -512,7 +512,7 @@ public class UserService {
                 String location = teamLocationRelation1.getLocation().getLocationName();
                 locationList1.add(location);
             }
-
+            teamAbstractDto1.setTeamId(team2.getTeamId());
             teamAbstractDto1.setTeamNeed(team2.getTeamMemberNeed());
             teamAbstractDto1.setTeamNowMember(team2.getTeamMemberNow());
             teamAbstractDto1.setTeamTitle(team2.getTeamTitle());


### PR DESCRIPTION
#89 
## 팀 검색 기능을 구현하였습니다.
어떻게 검색하는지 안나와서 그냥 제목으로 검색하는것으로 하였습니다
Pagination 처리까지 다 처리하였습니다.

## User/Apply 연결관계 수정
apply랑 user랑 연결관계가 없어서
일대다 연결로 변경하였습니다.

#91 
## 내가 지원한 것들에 대한 팀의 상태들에 따른 정보들을 확인 가능합니다.

## 각각에 대한 Id 정보추가
각각의 정보에 대해서 Id값을 추가하도록 하였습니다
