### PR TITLE
[FEAT/ADD] Heart(좋아요) 생성/삭제 기능 구현 + Service에 @Transactional 추가

### DIFF
--- a/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
+++ b/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
@@ -28,6 +28,7 @@ import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.team.repository.TeamRepository;
 import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -54,6 +55,7 @@ public class ApplyService {
     private final TeamUserRepository teamUserRepository;
     private final TeamLocationRelationRepository teamLocationRelationRepository;
     // 팀에 대한 지원서 작성
+    @Transactional
     public ApiResponseDto<SuccessResponse> postApply(UserDetails loginUser, Long teamId, ApplyPostDto applyPostDto) {
         Team team = teamRepository.findByTeamId(teamId)
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_TEAM));
@@ -85,6 +87,7 @@ public class ApplyService {
     }
 
     // 지원서 상세
+    @Transactional
     public ApiResponseDto<ApplyDetailDto> applyDetail(Long applyId) {
 
         Apply apply = applyRepository.findByApplyId(applyId)
@@ -118,6 +121,7 @@ public class ApplyService {
         return ResponseUtils.ok(applyDetailDto, null);
     }
     // type에 따라 내가 지원한 팀들을 볼 수 있는 기능
+    @Transactional
     public ApiResponseDto<ApplyTeamListDto> getApplyType(UserDetails loginUser, int pageNo, int pageSize, String sortBy, String type) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -184,6 +188,8 @@ public class ApplyService {
 
         return ResponseUtils.ok(teamListDto, null);
     }
+    // 내가 지원한 지원서나 팀을 볼 수 있음
+    @Transactional
     public ApiResponseDto<ApplyTeamDto> getApply(UserDetails loginUser) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -247,7 +253,8 @@ public class ApplyService {
         }
         return ResponseUtils.ok(applyTeamDto, null);
     }
-
+    // 나의 지원을 삭제함
+    @Transactional
     public ApiResponseDto<SuccessResponse> deleteApply(UserDetails loginUser, Long apply_id)
     {
         Optional<Apply> applyOptional = applyRepository.findById(apply_id);

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -41,7 +41,8 @@ public enum ErrorType {
     NOT_EXPERIENCE_YET(400, "경험 정보를 모두 기입해 주세요"),
     NOT_FOUND(400, "해당 정보가 존재하지 않습니다." ),
     INTERNAL_SERVER_ERROR(500, "서버에러"),
-    POSITION_NOT_PROVIDED(400, "포지션이 입력되지 않았습니다.");
+    POSITION_NOT_PROVIDED(400, "포지션이 입력되지 않았습니다."),
+    FOUND_LIKE(400, "이미 좋아요를 눌렀습니다");
 
 
     private int code;

--- a/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
+++ b/src/main/java/com/PuzzleU/Server/competition/controller/CompetitionController.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.competition.controller;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.competition.dto.CompetitionHomeTotalDto;
 import com.PuzzleU.Server.competition.dto.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.competition.dto.CompetitionSpecificDto;
@@ -10,6 +11,7 @@ import com.PuzzleU.Server.team.dto.TeamListDto;
 import com.PuzzleU.Server.team.dto.TeamSpecificDto;
 import com.PuzzleU.Server.team.service.TeamService;
 import com.PuzzleU.Server.user.dto.UserSimpleDto;
+import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -85,6 +87,20 @@ public class CompetitionController {
                                                           @RequestParam(value = "sortBy", defaultValue = "competitionId", required = false) String sortBy)
     {
         return userService.userSearch(loginUser, pageNo, pageSize, sortBy, search);
+    }
+    @PatchMapping("/homepage/{competition_id}")
+    public ApiResponseDto<SuccessResponse> heartCreate(@Valid
+    @AuthenticationPrincipal UserDetails loginUser,
+    @PathVariable Long competition_id)
+    {
+        return competitionService.heartCreate(loginUser, competition_id);
+    }
+    @DeleteMapping("/homepage/{competition_id}")
+    public ApiResponseDto<SuccessResponse> heartDelete(@Valid
+                                                       @AuthenticationPrincipal UserDetails loginUser,
+                                                       @PathVariable Long competition_id)
+    {
+        return competitionService.heartDelete(loginUser, competition_id);
     }
 
 

--- a/src/main/java/com/PuzzleU/Server/competition/repository/CompetitionRepository.java
+++ b/src/main/java/com/PuzzleU/Server/competition/repository/CompetitionRepository.java
@@ -39,5 +39,6 @@ public interface CompetitionRepository extends JpaRepository<Competition, Long> 
 
     @Query("SELECT c FROM Competition c WHERE c.competitionName LIKE %:keyword%")
     List<Competition> findByCompetitionName(@Param("keyword") String keyword, Pageable pageable);
+
 }
 

--- a/src/main/java/com/PuzzleU/Server/friendship/service/FriendshipService.java
+++ b/src/main/java/com/PuzzleU/Server/friendship/service/FriendshipService.java
@@ -9,6 +9,7 @@ import com.PuzzleU.Server.friendship.entity.FriendShip;
 import com.PuzzleU.Server.friendship.repository.FriendshipRepository;
 import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -24,6 +25,7 @@ public class FriendshipService {
     private final FriendshipRepository friendshipRepository;
 
     // 특정 유저에게 친구신청을 거는 것
+    @Transactional
     public ApiResponseDto<SuccessResponse> registerFriend(UserDetails loginUser, Long userId) {
         User user1 = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -47,6 +49,7 @@ public class FriendshipService {
         }
 
     }
+    @Transactional
     public ApiResponseDto<SuccessResponse> responseFriend(UserDetails loginUser, Long userId) {
         System.out.println(loginUser);
         System.out.println(userId);
@@ -64,6 +67,7 @@ public class FriendshipService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구수락이 완료되었습니다"), null);
 
     }
+    @Transactional
     public ApiResponseDto<SuccessResponse> deleteFriend(UserDetails loginUser, Long userId) {
         User user1 = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));

--- a/src/main/java/com/PuzzleU/Server/heart/Service/HeartService.java
+++ b/src/main/java/com/PuzzleU/Server/heart/Service/HeartService.java
@@ -1,0 +1,78 @@
+package com.PuzzleU.Server.heart.Service;
+
+import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ResponseUtils;
+import com.PuzzleU.Server.common.api.SuccessResponse;
+import com.PuzzleU.Server.common.enumSet.ErrorType;
+import com.PuzzleU.Server.common.exception.RestApiException;
+import com.PuzzleU.Server.competition.entity.Competition;
+import com.PuzzleU.Server.competition.repository.CompetitionRepository;
+import com.PuzzleU.Server.heart.entity.Heart;
+import com.PuzzleU.Server.heart.repository.HeartRepository;
+import com.PuzzleU.Server.user.entity.User;
+import com.PuzzleU.Server.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class HeartService {
+
+    private final UserRepository userRepository;
+    private final CompetitionRepository competitionRepository;
+    private final HeartRepository heartRepository;
+
+    @Transactional
+    public ApiResponseDto<SuccessResponse> heartCreate(UserDetails loginuser, Long competitionId)
+    {
+        User user = userRepository.findByUsername(loginuser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<Competition> competitionOptional = competitionRepository.findById(competitionId);
+        Competition competition = competitionOptional.orElseThrow(
+                () -> new RestApiException(ErrorType.NOT_FOUND_COMPETITION)
+        );
+        List<Heart> hearts = heartRepository.findByCompetitionAndUser(competition,user);
+        List<Heart> user_heart = heartRepository.findByCompetitionAndUserNot(competition,user);
+        int heart = hearts.size();
+        if (user_heart.size()==0)
+        {
+            heart +=1;
+            Heart heart_user = new Heart();
+            heart_user.setCompetition(competition);
+            heart_user.setUser(user);
+            heartRepository.save(heart_user);
+        }
+        else
+        {
+            throw new RestApiException(ErrorType.FOUND_LIKE);
+        }
+        competition.setCompetitionLike(heart);
+        competitionRepository.save(competition);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 눌렀습니다"), null);
+    }
+    @Transactional
+    public ApiResponseDto<SuccessResponse> heartDelete(UserDetails loginuser, Long competitionId)
+    {
+        User user = userRepository.findByUsername(loginuser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        Optional<Competition> competitionOptional = competitionRepository.findById(competitionId);
+        Competition competition = competitionOptional.orElseThrow(
+                () -> new RestApiException(ErrorType.NOT_FOUND_COMPETITION)
+        );
+        List<Heart> hearts = heartRepository.findByCompetitionAndUser(competition,user);
+        Heart user_heart = heartRepository.findOneByCompetitionAndUserNot(competition,user);
+        int heart = hearts.size();
+        heart -=1;
+        heartRepository.delete(user_heart);
+        competition.setCompetitionLike(heart);
+        competitionRepository.save(competition);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 취소하였습니다"), null);
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/heart/repository/HeartRepository.java
+++ b/src/main/java/com/PuzzleU/Server/heart/repository/HeartRepository.java
@@ -1,10 +1,23 @@
 package com.PuzzleU.Server.heart.repository;
 
+import com.PuzzleU.Server.competition.entity.Competition;
 import com.PuzzleU.Server.heart.entity.Heart;
+import com.PuzzleU.Server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface HeartRepository extends JpaRepository<Heart, Long>
 {
+    @Query("SELECT h FROM Heart h WHERE h.competition=:competition and h.user!=:user")
+    List<Heart> findByCompetitionAndUser(Competition competition, User user);
+
+    @Query("SELECT h FROM Heart h WHERE h.competition=:competition and h.user=:user")
+    List<Heart> findByCompetitionAndUserNot(Competition competition, User user);
+
+    @Query("SELECT h FROM Heart h WHERE h.competition=:competition and h.user=:user")
+    Heart findOneByCompetitionAndUserNot(Competition competition, User user);
 }

--- a/src/main/java/com/PuzzleU/Server/interest/service/InterestService.java
+++ b/src/main/java/com/PuzzleU/Server/interest/service/InterestService.java
@@ -4,6 +4,7 @@ import com.PuzzleU.Server.interest.dto.InterestDto;
 import com.PuzzleU.Server.interest.dto.InterestTypeDto;
 import com.PuzzleU.Server.interest.entity.Interest;
 import com.PuzzleU.Server.interest.repository.InterestRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +20,7 @@ public class InterestService {
     private final InterestRepository interestRepository;
 
     // interest list: 전체 interest list 반환 (공모전/직무/스터디로 구분)
+    @Transactional
     public List<InterestTypeDto> listAllInterest() {
 
         // interest list 받아오기

--- a/src/main/java/com/PuzzleU/Server/location/service/LocationService.java
+++ b/src/main/java/com/PuzzleU/Server/location/service/LocationService.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.location.service;
 import com.PuzzleU.Server.location.entity.Location;
 import com.PuzzleU.Server.location.dto.LocationDto;
 import com.PuzzleU.Server.location.repository.LocationRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ public class LocationService {
     private final LocationRepository locationRepository;
 
     // location list: 전체 location list 반환
+    @Transactional
     public List<LocationDto> listAllLocations() {
         List<Location> locationList = locationRepository.findAll();
 

--- a/src/main/java/com/PuzzleU/Server/major/service/MajorService.java
+++ b/src/main/java/com/PuzzleU/Server/major/service/MajorService.java
@@ -10,6 +10,7 @@ import com.PuzzleU.Server.major.entity.Major;
 import com.PuzzleU.Server.major.repository.MajorRepository;
 import com.PuzzleU.Server.university.entity.University;
 import com.PuzzleU.Server.university.repository.UniversityRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -29,6 +30,7 @@ public class MajorService {
 
 
     // 대학교에 대한 전공 검색 API
+    @Transactional
     public ApiResponseDto<MajorSearchTotalDto> searchMajorList(Long universityId, String searchKeyword, Pageable pageable) {
         University university = universityRepository.findByUniversityId(universityId)
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_UNIVERSITY));

--- a/src/main/java/com/PuzzleU/Server/position/service/PositionService.java
+++ b/src/main/java/com/PuzzleU/Server/position/service/PositionService.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.position.service;
 import com.PuzzleU.Server.position.dto.PositionDto;
 import com.PuzzleU.Server.position.entity.Position;
 import com.PuzzleU.Server.position.repository.PositionRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ public class PositionService {
     private final PositionRepository positionRepository;
 
     // position list: 전체 position list 반환
+    @Transactional
     public List<PositionDto> listAllPositions() {
         List<Position> positionList = positionRepository.findAll();
 

--- a/src/main/java/com/PuzzleU/Server/profile/service/ProfileService.java
+++ b/src/main/java/com/PuzzleU/Server/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.profile.service;
 import com.PuzzleU.Server.profile.dto.ProfileDto;
 import com.PuzzleU.Server.profile.entity.Profile;
 import com.PuzzleU.Server.profile.repository.ProfileRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ public class ProfileService {
     private final ProfileRepository profileRepository;
 
     // profile list: 전체 profile list 반환
+    @Transactional
     public List<ProfileDto> listAllProfiles() {
         List<Profile> profileList = profileRepository.findAll();
 

--- a/src/main/java/com/PuzzleU/Server/skillset/service/SkillsetService.java
+++ b/src/main/java/com/PuzzleU/Server/skillset/service/SkillsetService.java
@@ -15,6 +15,7 @@ import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.common.exception.RestApiException;
 import com.PuzzleU.Server.user.repository.UserRepository;
 import com.PuzzleU.Server.relations.repository.UserSkillsetRelationRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,6 +36,7 @@ public class SkillsetService {
     private final UserSkillsetRelationRepository userSkillsetRelationRepository;
 
     // 유저가 본인의 스킬셋을 등록가능한 API
+    @Transactional
     public ApiResponseDto<SuccessResponse> createSkillset(
             UserDetails loginUser, SkillSetListDto skillsetList
     )
@@ -62,6 +64,7 @@ public class SkillsetService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 저장완료"), null);
 
     }
+    @Transactional
     // 유저가 자신의 스킬셋을 삭제가능함
     public ApiResponseDto<SuccessResponse> deleteSkillset(
             UserDetails loginUser, Long userSkillsetId
@@ -79,6 +82,7 @@ public class SkillsetService {
 
     }
     // 유저가 자신이 등록한 스킬셋의 리스트를 확인가능한 API
+    @Transactional
     public ApiResponseDto<List<UserSkillsetRelationListDto>> getSkillsetList(UserDetails loginUser) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -126,6 +126,7 @@ public class TeamService {
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 생성완료"), null);
     }
     // 구인글 수정
+    @Transactional
     public ApiResponseDto<SuccessResponse> teamUpdate(TeamCreateDto teamCreateDto, Long competitionId,
                                                       List<Long> teamMember, UserDetails loginUser,
                                                       List<Long> locations, List<Long> positions, Long teamId) {
@@ -209,6 +210,7 @@ public class TeamService {
         }
         // 구인글 삭제
     }
+    @Transactional
     public ApiResponseDto<SuccessResponse> teamdelete(
             Long teamId,
             UserDetails loginUser
@@ -316,6 +318,8 @@ public class TeamService {
         friendShipSearchResponseDto.setTotalElements(friendShips.getTotalElements());
      return ResponseUtils.ok(friendShipSearchResponseDto, null)  ;
     }
+    // 내가 만든 팀에 대한 정보를 모두 가져온다
+    @Transactional
     public ApiResponseDto<TeamApplyDto> getTeamApplyTotal(UserDetails loginUser) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -374,6 +378,8 @@ public class TeamService {
         }
         return ResponseUtils.ok(teamApplyDto, null);
     }
+    @Transactional
+    // 타입에 따라 내가 만든 팀의 정보를 가져온다
     public ApiResponseDto<TeamListDto> getTeamApplyType(UserDetails loginUser, int pageNo, int pageSize, String sortBy, String type) {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -432,6 +438,8 @@ public class TeamService {
 
         return ResponseUtils.ok(teamListDto, null);
     }
+    // 팀의 상태(진행/완료)를 수정한다
+    @Transactional
     public ApiResponseDto<SuccessResponse> teamStatus(UserDetails loginUser, Long team_id, TeamStatusDto teamStatusDto)
     {
         Optional<Team> teamOptional  = teamRepository.findById(team_id);

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -120,8 +120,10 @@ public class TeamService {
                     .build();
             teamLocationRelationRepository.saveAndFlush(teamLocationRelation);
         }
-
-
+        int competetion_team = competition.getCompetitionMatching();
+        competetion_team+=1;
+        competition.setCompetitionMatching(competetion_team);
+        competitionRepository.save(competition);
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 생성완료"), null);
     }

--- a/src/main/java/com/PuzzleU/Server/university/service/UniversityService.java
+++ b/src/main/java/com/PuzzleU/Server/university/service/UniversityService.java
@@ -69,6 +69,7 @@ public class UniversityService {
     }
 
     // 대학교 검색 API
+    @Transactional
     public ApiResponseDto<UniversitySearchTotalDto> searchUniversityList(String searchKeyword, String type, Pageable pageable) {
         UniversityType universityType = UniversityType.UNIVERSITY;
 


### PR DESCRIPTION
#100 
## Heart
Competition에 대해서 유저가 heart를 누르면 자동으로 competition의 like가 변경되도록 하였습니다(삭제 동일)

## @Transactional
Transactional 어노테이션을 모든 service api에 넣었는데
jakrta랑 springframeword 어노테이션 두개의 차이가 애매모호 합니다

## 코드이동
userService에 있던 각각의 entity api를 각각의 파일로 옮겨 주었습니다

## TeamMatching update
팀의 생성하거나 삭제시에 competition의 Matching 속성을 각각 +1 -1하도록 변경