### PR TITLE
[FEAT] Swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'com.google.code.gson:gson:2.8.7'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'com.google.code.gson:gson:2.8.7'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 

--- a/src/main/java/com/PuzzleU/Server/ServerApplication.java
+++ b/src/main/java/com/PuzzleU/Server/ServerApplication.java
@@ -9,6 +9,7 @@ import org.springframework.data.web.PageableDefault;
 @EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
+//d
 public class ServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);

--- a/src/main/java/com/PuzzleU/Server/ServerApplication.java
+++ b/src/main/java/com/PuzzleU/Server/ServerApplication.java
@@ -9,7 +9,6 @@ import org.springframework.data.web.PageableDefault;
 @EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
-
 public class ServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);

--- a/src/main/java/com/PuzzleU/Server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.PuzzleU.Server.common.config;
+
+
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@OpenAPIDefinition(
+        info = @Info(title = "PuzzleU API 명세서",
+                description = "PuzzleU API 명세서",
+                version = "v0.0.1"))
+@SecurityScheme(
+        name = "Bearer Authentication",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("PuzzleU")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
@@ -52,13 +52,13 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests((authorizeRequests)->
                         authorizeRequests
                                 .requestMatchers("/api/user/**").permitAll()
+                                .requestMatchers("/v3/api-docs/**").permitAll()
+                                .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/api/competition/**").permitAll()
                                 .requestMatchers("/api/oauth/**").permitAll()
                                 .requestMatchers("/api/team/**").permitAll()
                                 .requestMatchers("/api/university/**").permitAll()
                                 .requestMatchers("/api/apply/**").permitAll()
-                                .requestMatchers(HttpMethod.GET,"/api/posts").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/post/{id}").permitAll()
                                 .requestMatchers(HttpMethod.GET, "api/splash").permitAll()
                                 .anyRequest().authenticated()
 

--- a/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
@@ -51,7 +51,7 @@ public class WebSecurityConfig {
                 )
                 .authorizeHttpRequests((authorizeRequests)->
                         authorizeRequests
-                                .requestMatchers("/api/user/**").permitAll()
+                                .requestMatchers("/api/user/**", "/actuator/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**").permitAll()
                                 .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/api/competition/**").permitAll()

--- a/src/main/java/com/PuzzleU/Server/competition/dto/CompetitionHomePageDto.java
+++ b/src/main/java/com/PuzzleU/Server/competition/dto/CompetitionHomePageDto.java
@@ -13,13 +13,14 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CompetitionHomePageDto {
+    private Long competitionId;
     @Size(max = 100)
     private String competitionName;
     private Integer CompetitionVisit;
     private Integer CompetitionMatching;
     private List<CompetitionType> competitionTypeList;
     private Integer CompetitionDday;
-    private LocalDateTime createdAt;
+    private String createdAt;
 
 
 }

--- a/src/main/java/com/PuzzleU/Server/competition/entity/Competition.java
+++ b/src/main/java/com/PuzzleU/Server/competition/entity/Competition.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.competition.entity;
 import com.PuzzleU.Server.common.enumSet.BaseEntity;
 import com.PuzzleU.Server.common.enumSet.CompetitionType;
 import com.PuzzleU.Server.heart.entity.Heart;
+import com.PuzzleU.Server.relations.entity.CompetitionInterestRelation;
 import com.PuzzleU.Server.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
@@ -408,6 +408,7 @@ public class CompetitionService {
 
 
     }
+    //a
     @Scheduled(cron = "0 0 0 * * ?")
     public void updateCompetitionDday() {
         List<Competition> competitions = competitionRepository.findAll();

--- a/src/main/java/com/PuzzleU/Server/interest/entity/Interest.java
+++ b/src/main/java/com/PuzzleU/Server/interest/entity/Interest.java
@@ -1,7 +1,7 @@
 package com.PuzzleU.Server.interest.entity;
 
 import com.PuzzleU.Server.common.enumSet.InterestTypes;
-import com.PuzzleU.Server.competition.entity.CompetitionInterestRelation;
+import com.PuzzleU.Server.relations.entity.CompetitionInterestRelation;
 import com.PuzzleU.Server.relations.entity.UserInterestRelation;
 import jakarta.persistence.*;
 

--- a/src/main/java/com/PuzzleU/Server/relations/entity/CompetitionInterestRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/CompetitionInterestRelation.java
@@ -1,5 +1,6 @@
-package com.PuzzleU.Server.competition.entity;
+package com.PuzzleU.Server.relations.entity;
 
+import com.PuzzleU.Server.competition.entity.Competition;
 import com.PuzzleU.Server.interest.entity.Interest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
#104 
## Swagger 추가
swagger를 추가해주었습니다
swagger란 -> 코드상의 api 문서들을 한번에 종합해서 보기 쉽게 만들어주는 postman 같은것(postman보다 UI/UX는 안좋은듯)

### 해야하는 것
1 .application.properties에
spring.mvc.pathmatch.matching-strategy=ant_path_matcher
springdoc.swagger-ui.groups-order=DESC
springdoc.swagger-ui.tags-sorter=alpha
springdoc.swagger-ui.operations-sorter=method
추가 해주세요

2. config에 
.requestMatchers("/v3/api-docs/**").permitAll()
                                .requestMatchers("/swagger-ui/**").permitAll()
추가해 주세욤

## @Scheduled로 자정마다 없데이트
@Scheduled(cron = "0 0 0 * * ?")
를 사용하여서 매 자정마다 d-day를 업데이트 해줍니다

## competition homepage에서 
competitionEndReverse(마감빠른순), competitionEnd(마감느린순,) CompetitionLike(인기순), competitionId(최신순), competitionVisit(조회순), competitionMatching(빌딩순)  의 sortby로 정렬이 되도록 해주었습니다

#106 
# Actuator 추가
아직 배포 안했으니
# Actuator 보안 설정 샘플

## 1. 활성화 상태를 기본값으로 false로 만들고, 필요한 endpoint를 enable해서 사용한다.
management.endpoints.enabled-by-default = false

management.endpoint.info.enabled = true
management.endpoint.health.enabled = true

## 2. 필요한 endpoint만 노출해서 사용한다.
management.endpoints.jmx.exposure.exclude = *
management.endpoints.web.exposure.include = info, health
만 properties에 추가해주세욤