### PR TITLE
[FEAT] 대기 중인 지원자 & 수락/거절 기능 구현

### DIFF
--- a/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
+++ b/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
@@ -1,6 +1,6 @@
 package com.PuzzleU.Server.apply.dto;
 
-import com.PuzzleU.Server.profile.entity.Profile;
+import com.PuzzleU.Server.profile.dto.ProfileDto;
 import lombok.*;
 
 @Getter
@@ -10,7 +10,7 @@ import lombok.*;
 @AllArgsConstructor
 public class UserApplyDto {
     private Long UserId;
-    private Profile UserProfile;
+    private ProfileDto UserProfile;
     private String UserKoreaName;
     private String UserRepresentativeProfileSentence;
 

--- a/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
+++ b/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
@@ -1,0 +1,19 @@
+package com.PuzzleU.Server.apply.dto;
+
+import com.PuzzleU.Server.profile.entity.Profile;
+import lombok.*;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserApplyDto {
+    private Long UserId;
+    private Profile UserProfile;
+    private String UserKoreaName;
+    private String UserRepresentativeProfileSentence;
+
+    private Long ApplyId;
+    private String ApplyTitle;
+}

--- a/src/main/java/com/PuzzleU/Server/apply/entity/Apply.java
+++ b/src/main/java/com/PuzzleU/Server/apply/entity/Apply.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.apply.entity;
 import com.PuzzleU.Server.common.enumSet.ApplyStatus;
 import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -30,10 +31,12 @@ public class Apply {
 
     // 의존 관계 매핑 (Team)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "team_id")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "user")
     private User user;
 }

--- a/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/PuzzleU/Server/apply/repository/ApplyRepository.java
@@ -20,13 +20,13 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     List<Team> findByUser(User user, org.springframework.data.domain.Pageable pageable);
     @Query("SELECT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'WAITING'")
     List<Team> findByUserAndApplyStatusIsWaiting(User user, org.springframework.data.domain.Pageable pageable);
-    @Query("SELECT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'FINISHED'")
+    @Query("SELECT a.team FROM Apply a WHERE a.user = :user AND (a.applyStatus = 'ACCEPTED' OR a.applyStatus = 'REJECTED')")
     List<Team> findByUserAndApplyStatusIsFinished(User user, org.springframework.data.domain.Pageable pageable);
 
     @Query("SELECT DISTINCT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'WAITING'")
     List<Team> findFirstByUserAndApplyStatusIsWaitingOne(User user);
 
-    @Query("SELECT DISTINCT a.team FROM Apply a WHERE a.user = :user AND a.applyStatus = 'FINISHED'")
+    @Query("SELECT DISTINCT a.team FROM Apply a WHERE a.user = :user AND (a.applyStatus = 'ACCEPTED' OR a.applyStatus = 'REJECTED')")
     List<Team> findFirstByUserAndApplyStatusIsFinishedOne(User user);
 
     Optional<Apply> findByUserAndTeam(User user, Team team);

--- a/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
+++ b/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
@@ -123,6 +123,7 @@ public class ApplyService {
 
         return ResponseUtils.ok(applyDetailDto, null);
     }
+
     // type에 따라 내가 지원한 팀들을 볼 수 있는 기능
     @Transactional
     public ApiResponseDto<ApplyTeamListDto> getApplyType(UserDetails loginUser, int pageNo, int pageSize, String sortBy, String type) {

--- a/src/main/java/com/PuzzleU/Server/common/api/ResponseUtils.java
+++ b/src/main/java/com/PuzzleU/Server/common/api/ResponseUtils.java
@@ -1,5 +1,8 @@
 package com.PuzzleU.Server.common.api;
 
+import lombok.Getter;
+
+@Getter
 public class ResponseUtils {
     //d
     // 요청 성공인 경우

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ApplyStatus.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ApplyStatus.java
@@ -1,5 +1,5 @@
 package com.PuzzleU.Server.common.enumSet;
 
 public enum ApplyStatus {
-    WAITING, FINISHED, CANCEL // 대기, 완료, 취소
+    WAITING, ACCEPTED, REJECTED, CANCEL // 대기, 수락, 거절, 취소
 }

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -42,7 +42,8 @@ public enum ErrorType {
     NOT_FOUND(400, "해당 정보가 존재하지 않습니다." ),
     INTERNAL_SERVER_ERROR(500, "서버에러"),
     POSITION_NOT_PROVIDED(400, "포지션이 입력되지 않았습니다."),
-    FOUND_LIKE(400, "이미 좋아요를 눌렀습니다");
+    FOUND_LIKE(400, "이미 좋아요를 눌렀습니다"),
+    NO_PERMISSION_TO_APPLICATION_LIST(403, "지원서 리스트를 열람할 권한이 없습니다.");
 
 
     private int code;

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -43,7 +43,9 @@ public enum ErrorType {
     INTERNAL_SERVER_ERROR(500, "서버에러"),
     POSITION_NOT_PROVIDED(400, "포지션이 입력되지 않았습니다."),
     FOUND_LIKE(400, "이미 좋아요를 눌렀습니다"),
-    NO_PERMISSION_TO_APPLICATION_LIST(403, "지원서 리스트를 열람할 권한이 없습니다.");
+    NO_PERMISSION_TO_APPLICATION_LIST(403, "지원서 리스트를 열람할 권한이 없습니다."),
+    NOT_MATCH_ACCEPT_REJECT(400, "요청값을 확인하세요. ACCEPT 또는 REJECT로만 요청 가능합니다."),
+    NO_PERMISSION_TO_ACCEPT_APPLY(403, "지원서를 수락 또는 거절할 권한이 없습니다.");
 
 
     private int code;

--- a/src/main/java/com/PuzzleU/Server/competition/entity/Competition.java
+++ b/src/main/java/com/PuzzleU/Server/competition/entity/Competition.java
@@ -5,6 +5,7 @@ import com.PuzzleU.Server.common.enumSet.CompetitionType;
 import com.PuzzleU.Server.heart.entity.Heart;
 import com.PuzzleU.Server.relations.entity.CompetitionInterestRelation;
 import com.PuzzleU.Server.team.entity.Team;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -71,13 +72,15 @@ public class Competition extends BaseEntity {
     @Column(name = "competition_type")
     private List<CompetitionType> competitionTypes;
 
-
-    @OneToMany(mappedBy = "competition",cascade = CascadeType.ALL)
+    @JsonIgnore
+    @OneToMany(mappedBy = "competition", cascade = CascadeType.ALL)
     private List<Team> team = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "competition",cascade = CascadeType.ALL)
     private List<Heart> heart = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "competition", cascade = CascadeType.REMOVE)
     private List<CompetitionInterestRelation> competitionInterestRelations = new ArrayList<>();
 

--- a/src/main/java/com/PuzzleU/Server/experience/entity/Experience.java
+++ b/src/main/java/com/PuzzleU/Server/experience/entity/Experience.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.experience.entity;
 
 import com.PuzzleU.Server.common.enumSet.ExperienceType;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -41,7 +42,8 @@ public class Experience {
 
     //de
     // 의존 관계 매핑 (User)
-    @ManyToOne
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/PuzzleU/Server/friendship/entity/FriendShip.java
+++ b/src/main/java/com/PuzzleU/Server/friendship/entity/FriendShip.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.friendship.entity;
 
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,11 +21,12 @@ public class FriendShip {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long friendShipId;
 
-
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users1")
     private User user1;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users2")
     private User user2;

--- a/src/main/java/com/PuzzleU/Server/heart/entity/Heart.java
+++ b/src/main/java/com/PuzzleU/Server/heart/entity/Heart.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.heart.entity;
 
 import com.PuzzleU.Server.competition.entity.Competition;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,10 +20,12 @@ public class Heart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long heartId;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id")
     private Competition competition;

--- a/src/main/java/com/PuzzleU/Server/interest/entity/Interest.java
+++ b/src/main/java/com/PuzzleU/Server/interest/entity/Interest.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.interest.entity;
 import com.PuzzleU.Server.common.enumSet.InterestTypes;
 import com.PuzzleU.Server.relations.entity.CompetitionInterestRelation;
 import com.PuzzleU.Server.relations.entity.UserInterestRelation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import lombok.*;
@@ -30,9 +31,11 @@ public class Interest {
     @Enumerated(value = EnumType.STRING)
     private InterestTypes interestType;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "interest", cascade = CascadeType.REMOVE)
     private List<UserInterestRelation> userInterestRelation = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "interest", cascade = CascadeType.REMOVE)
     private List<CompetitionInterestRelation> competitionInterestRelations = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/location/entity/Location.java
+++ b/src/main/java/com/PuzzleU/Server/location/entity/Location.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.location.entity;
 
 import com.PuzzleU.Server.relations.entity.UserLocationRelation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,7 +25,8 @@ public class Location {
     @Column(name = "location_name")
     private String locationName;
 
-    @OneToMany(mappedBy = "location",cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    @OneToMany(mappedBy = "location", cascade = CascadeType.REMOVE)
     private List<UserLocationRelation> userLocationRelation = new ArrayList<>();
 
 }

--- a/src/main/java/com/PuzzleU/Server/major/entity/Major.java
+++ b/src/main/java/com/PuzzleU/Server/major/entity/Major.java
@@ -1,7 +1,7 @@
 package com.PuzzleU.Server.major.entity;
 
-import com.PuzzleU.Server.relations.entity.UserUniversityRelation;
 import com.PuzzleU.Server.university.entity.University;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +23,7 @@ public class Major {
     private String majorName; // 전공 이름
 
     // 의존 관계 매핑 (University)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university_id")
     private University university;

--- a/src/main/java/com/PuzzleU/Server/position/entity/Position.java
+++ b/src/main/java/com/PuzzleU/Server/position/entity/Position.java
@@ -1,8 +1,8 @@
 package com.PuzzleU.Server.position.entity;
 
 import com.PuzzleU.Server.relations.entity.TeamPositionRelation;
-import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,12 +26,15 @@ public class Position {
     @Column(name = "position_name", length = 10)
     private String positionName; // 포지션 이름
 
+    @JsonIgnore
     @OneToMany(mappedBy = "userPosition1")
     private List<User> userList1 = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "userPosition2")
     private List<User> userList2 = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "position", cascade = CascadeType.REMOVE)
     private List<TeamPositionRelation> teamPositionRelations;
 }

--- a/src/main/java/com/PuzzleU/Server/profile/entity/Profile.java
+++ b/src/main/java/com/PuzzleU/Server/profile/entity/Profile.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.profile.entity;
 
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,6 +25,7 @@ public class Profile {
     @Column(name = "profile_url")
     private String profielUrl;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "userProfile")
     private List<User> user = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/relations/entity/CompetitionInterestRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/CompetitionInterestRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.competition.entity.Competition;
 import com.PuzzleU.Server.interest.entity.Interest;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,12 +21,14 @@ public class CompetitionInterestRelation {
     private Long competitionInterestRelationId;
 
     // 의존 관계 매핑 (Competition)
-    @ManyToOne
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id")
     private Competition competition;
 
     // 의존관계 매핑 (Interest)
-    @ManyToOne
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interest_id")
     private Interest interest;
 }

--- a/src/main/java/com/PuzzleU/Server/relations/entity/PositionApplyRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/PositionApplyRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.apply.entity.Apply;
 import com.PuzzleU.Server.position.entity.Position;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,11 +19,13 @@ public class PositionApplyRelation {
 
     // 의존 관계 매핑 (Position)
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "position_id")
     private Position position;
 
     // 의존관계 매핑 (Apply)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "apply_id")
     private Apply apply;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/TeamLocationRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/TeamLocationRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.location.entity.Location;
 import com.PuzzleU.Server.team.entity.Team;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,10 +18,12 @@ public class TeamLocationRelation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long teamLocationRelationId;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private Location location;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/TeamPositionRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/TeamPositionRelation.java
@@ -2,8 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.position.entity.Position;
 import com.PuzzleU.Server.team.entity.Team;
-import com.PuzzleU.Server.university.entity.University;
-import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,11 +20,13 @@ public class TeamPositionRelation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long teamPositionId;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
 
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "position_id")
     private Position position;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/TeamUserRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/TeamUserRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.team.entity.Team;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,10 +21,12 @@ public class TeamUserRelation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long teamUserRelationId;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     private User user;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/UserInterestRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/UserInterestRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.interest.entity.Interest;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,11 +20,13 @@ public class UserInterestRelation {
     private Long userInterestRelationId;
 
     // 의존 관계 매핑 (User)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     private User user;
 
     // 의존관계 매핑 (Interest)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interest_id")
     private Interest interest;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/UserLocationRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/UserLocationRelation.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.location.entity.Location;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,11 +19,13 @@ public class UserLocationRelation {
     private Long userLocationRelationId;
 
     // 의존 관계 매핑 (User)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     private User user;
 
     // 의존관계 매핑 (Location)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private Location location;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/UserSkillsetRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/UserSkillsetRelation.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.relations.entity;
 import com.PuzzleU.Server.common.enumSet.Level;
 import com.PuzzleU.Server.skillset.entity.Skillset;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,11 +26,13 @@ public class UserSkillsetRelation {
     private Level level;
 
     // 의존 관계 매핑 (User)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     private User user;
 
     // 의존관계 매핑 (Skillset)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "skillset_id")
     private Skillset skillset;

--- a/src/main/java/com/PuzzleU/Server/relations/entity/UserUniversityRelation.java
+++ b/src/main/java/com/PuzzleU/Server/relations/entity/UserUniversityRelation.java
@@ -1,9 +1,9 @@
 package com.PuzzleU.Server.relations.entity;
 
 import com.PuzzleU.Server.common.enumSet.UniversityStatus;
-import com.PuzzleU.Server.major.entity.Major;
 import com.PuzzleU.Server.university.entity.University;
 import com.PuzzleU.Server.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,11 +22,13 @@ public class UserUniversityRelation {
     private Long userUniversityId;
 
     // 의존 관계 매핑 (User)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     private User user;
 
     // 의존관계 매핑 (Skillset)
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university_id")
     private University university;

--- a/src/main/java/com/PuzzleU/Server/relations/repository/TeamPositionRelationRepository.java
+++ b/src/main/java/com/PuzzleU/Server/relations/repository/TeamPositionRelationRepository.java
@@ -12,7 +12,8 @@ import java.util.List;
 @Repository
 public interface TeamPositionRelationRepository extends JpaRepository<TeamPositionRelation, Long> {
 
-    @Query("SELECT t FROM TeamPositionRelation t WHERE t.team =:team")
+    @Query("SELECT t.position FROM TeamPositionRelation t WHERE t.team =:team")
+
     List<Position>findByTeam(Team team);
 
 }

--- a/src/main/java/com/PuzzleU/Server/skillset/entity/Skillset.java
+++ b/src/main/java/com/PuzzleU/Server/skillset/entity/Skillset.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.skillset.entity;
 
 import com.PuzzleU.Server.relations.entity.UserSkillsetRelation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,6 +28,7 @@ public class Skillset {
     @Column(length = 200)
     private String skillsetLogo;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "skillset",cascade = CascadeType.REMOVE)
     private List<UserSkillsetRelation> userSkillsetRelation = new ArrayList<>();
     //

--- a/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
@@ -4,13 +4,12 @@ import com.PuzzleU.Server.common.api.ApiResponseDto;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.competition.dto.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
+import com.PuzzleU.Server.team.dto.AcceptOrRejectRequestDto;
 import com.PuzzleU.Server.team.dto.TeamApplyListDto;
 import com.PuzzleU.Server.team.dto.TeamCreateDto;
 import com.PuzzleU.Server.team.service.TeamService;
-import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.service.UserService;
 import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -78,5 +77,13 @@ public class TeamController {
         return teamService.readTeamApplyList(loginUser, teamId);
     }
 
+    @PatchMapping("{teamId}/apply/{applyId}")
+    public ApiResponseDto<SuccessResponse> applyAcceptOrReject(
+            @AuthenticationPrincipal UserDetails loginUser,
+            @PathVariable Long teamId,
+            @PathVariable Long applyId,
+            @RequestBody AcceptOrRejectRequestDto acceptOrRejectDto) {
+        return teamService.applyAcceptOrReject(loginUser, teamId, applyId, acceptOrRejectDto);
+    }
 
 }

--- a/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
+++ b/src/main/java/com/PuzzleU/Server/team/controller/TeamController.java
@@ -4,11 +4,13 @@ import com.PuzzleU.Server.common.api.ApiResponseDto;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.competition.dto.CompetitionSearchTotalDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
+import com.PuzzleU.Server.team.dto.TeamApplyListDto;
 import com.PuzzleU.Server.team.dto.TeamCreateDto;
 import com.PuzzleU.Server.team.service.TeamService;
 import com.PuzzleU.Server.user.entity.User;
 import com.PuzzleU.Server.user.service.UserService;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -70,5 +72,11 @@ public class TeamController {
     {
         return teamService.getfriendRegister(keyword, loginUser,pageNo,pageSize, sortBy);
     }
+
+    @GetMapping("/{teamId}/apply")
+    public ApiResponseDto<TeamApplyListDto> readTeamApplyList(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long teamId) {
+        return teamService.readTeamApplyList(loginUser, teamId);
+    }
+
 
 }

--- a/src/main/java/com/PuzzleU/Server/team/dto/AcceptOrRejectRequestDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/AcceptOrRejectRequestDto.java
@@ -1,0 +1,13 @@
+package com.PuzzleU.Server.team.dto;
+
+import lombok.*;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcceptOrRejectRequestDto {
+    private String acceptOrReject;
+}

--- a/src/main/java/com/PuzzleU/Server/team/dto/SimpleTeamDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/SimpleTeamDto.java
@@ -1,0 +1,24 @@
+package com.PuzzleU.Server.team.dto;
+
+import com.PuzzleU.Server.location.dto.LocationDto;
+import com.PuzzleU.Server.position.dto.PositionDto;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SimpleTeamDto {
+    private Long teamId;
+    private String teamTitle;
+    private String teamWriter;
+    private List<PositionDto> positionList;
+    private Integer teamNowMember;
+    private Integer teamNeed;
+    private Boolean teamUntact;
+    private List<LocationDto> teamLocations;
+    private String CompetitionPoster;
+}

--- a/src/main/java/com/PuzzleU/Server/team/dto/TeamApplyListDto.java
+++ b/src/main/java/com/PuzzleU/Server/team/dto/TeamApplyListDto.java
@@ -1,0 +1,16 @@
+package com.PuzzleU.Server.team.dto;
+
+import com.PuzzleU.Server.apply.dto.UserApplyDto;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamApplyListDto {
+    private SimpleTeamDto Team;
+    private List<UserApplyDto> ApplyList;
+}

--- a/src/main/java/com/PuzzleU/Server/team/entity/Team.java
+++ b/src/main/java/com/PuzzleU/Server/team/entity/Team.java
@@ -1,12 +1,17 @@
 package com.PuzzleU.Server.team.entity;
 
-import com.PuzzleU.Server.common.enumSet.BaseEntity;
 import com.PuzzleU.Server.apply.entity.Apply;
+import com.PuzzleU.Server.common.enumSet.BaseEntity;
 import com.PuzzleU.Server.competition.entity.Competition;
-import com.PuzzleU.Server.position.entity.Position;
+import com.PuzzleU.Server.relations.entity.TeamLocationRelation;
 import com.PuzzleU.Server.relations.entity.TeamPositionRelation;
+import com.PuzzleU.Server.relations.entity.TeamUserRelation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
@@ -49,13 +54,24 @@ public class Team extends BaseEntity {
     @Column(name = "team_status",nullable = true)
     private Boolean teamStatus;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id")
     private Competition competition;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
     private List<Apply> applyList = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
     private List<TeamPositionRelation> teamPositionRelations = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
+    private List<TeamLocationRelation> teamLocationRelations = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE)
+    private List<TeamUserRelation> teamUserRelations = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -18,6 +18,8 @@ import com.PuzzleU.Server.location.repository.LocationRepository;
 import com.PuzzleU.Server.position.dto.PositionDto;
 import com.PuzzleU.Server.position.entity.Position;
 import com.PuzzleU.Server.position.repository.PositionRepository;
+import com.PuzzleU.Server.profile.dto.ProfileDto;
+import com.PuzzleU.Server.profile.entity.Profile;
 import com.PuzzleU.Server.relations.entity.TeamLocationRelation;
 import com.PuzzleU.Server.relations.entity.TeamPositionRelation;
 import com.PuzzleU.Server.relations.entity.TeamUserRelation;
@@ -61,6 +63,7 @@ public class TeamService {
     private final PositionRepository positionRepository;
     private final ApplyRepository applyRepository;
     private final TeamPositionRelationRepository teamPositionRelationRepository;
+
     // 팀 구인글을 등록하는 API
     @Transactional
     public ApiResponseDto<SuccessResponse> teamcreate(
@@ -68,22 +71,20 @@ public class TeamService {
             Long competitionId,
             List<Long> teamMember,
             UserDetails loginUser
-            ,List<Long> locations,
+            , List<Long> locations,
             List<Long> positions
-    )
-    {
+    ) {
 
         User loginuser = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Optional<Competition> competitionOptional = competitionRepository.findById(competitionId);
         Competition competition = competitionOptional.orElseThrow(
-                ()-> new RestApiException(ErrorType.NOT_FOUND_COMPETITION)
+                () -> new RestApiException(ErrorType.NOT_FOUND_COMPETITION)
         );
-        List<Position>positionList = new ArrayList<>();
-        for(Long positionId : positions)
-        {
+        List<Position> positionList = new ArrayList<>();
+        for (Long positionId : positions) {
             Optional<Position> positionOptional = positionRepository.findById(positionId);
-            Position position = positionOptional.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_POSITION));
+            Position position = positionOptional.orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_POSITION));
             positionList.add(position);
         }
         Team team = new Team();
@@ -95,31 +96,29 @@ public class TeamService {
         team.setTeamContent(teamCreateDto.getTeamContent());
         team.setTeamStatus(teamCreateDto.getTeamStatus());
         team.setCompetition(competition);
-        team.setTeamMemberNow(teamMember.size()+1);
+        team.setTeamMemberNow(teamMember.size() + 1);
 
         teamRepository.save(team);
 
-        TeamUserRelation teamUserRelationWriter=  TeamUserRelation.builder()
+        TeamUserRelation teamUserRelationWriter = TeamUserRelation.builder()
                 .team(team)
                 .user(loginuser)
                 .isWriter(true)
                 .build();
         teamUserRepository.saveAndFlush(teamUserRelationWriter);
-        for(Long userId : teamMember)
-        {
+        for (Long userId : teamMember) {
             Optional<User> userOptional = userRepository.findById(userId);
-                    User user = userOptional.orElseThrow(
-                    ()-> new RestApiException(ErrorType.NOT_FOUND_USER)
+            User user = userOptional.orElseThrow(
+                    () -> new RestApiException(ErrorType.NOT_FOUND_USER)
             );
-            TeamUserRelation teamUserRelation=  TeamUserRelation.builder()
+            TeamUserRelation teamUserRelation = TeamUserRelation.builder()
                     .team(team)
                     .user(user)
                     .isWriter(false)
                     .build();
             teamUserRepository.saveAndFlush(teamUserRelation);
         }
-        for(Long locationId : locations)
-        {
+        for (Long locationId : locations) {
             Optional<Location> locationOptional = locationRepository.findById(locationId);
             Location location = locationOptional.orElseThrow(
                     () -> new RestApiException(ErrorType.NOT_FOUND_LOCATION)
@@ -131,12 +130,13 @@ public class TeamService {
             teamLocationRelationRepository.saveAndFlush(teamLocationRelation);
         }
         int competetion_team = competition.getCompetitionMatching();
-        competetion_team+=1;
+        competetion_team += 1;
         competition.setCompetitionMatching(competetion_team);
         competitionRepository.save(competition);
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 생성완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 생성완료"), null);
     }
+
     // 구인글 수정
     @Transactional
     public ApiResponseDto<SuccessResponse> teamUpdate(TeamCreateDto teamCreateDto, Long competitionId,
@@ -170,7 +170,7 @@ public class TeamService {
             team.setTeamContent(teamCreateDto.getTeamContent());
             team.setTeamStatus(teamCreateDto.getTeamStatus());
             team.setCompetition(competition);
-            team.setTeamMemberNow(teamMember.size()+1);
+            team.setTeamMemberNow(teamMember.size() + 1);
             teamRepository.save(team);
 
             List<TeamUserRelation> existingRelations = teamUserRepository.findByTeam(team);
@@ -214,8 +214,7 @@ public class TeamService {
             teamUserRelation1.setTeam(team);
             teamUserRelation1.setIsWriter(true);
             teamUserRepository.save(teamUserRelation1);
-            for(Position position: positionList)
-            {
+            for (Position position : positionList) {
                 TeamPositionRelation teamPositionRelation = new TeamPositionRelation();
                 teamPositionRelation.setPosition(position);
                 teamPositionRelation.setTeam(team);
@@ -228,38 +227,34 @@ public class TeamService {
         }
         // 구인글 삭제
     }
+
     @Transactional
     public ApiResponseDto<SuccessResponse> teamdelete(
             Long teamId,
             UserDetails loginUser
-    )
-    {
+    ) {
         System.out.println(loginUser);
         User user = userRepository.findByUsername(loginUser.getUsername()).orElseThrow(
-                ()-> new RestApiException(ErrorType.NOT_FOUND_USER)
+                () -> new RestApiException(ErrorType.NOT_FOUND_USER)
         );
-        Optional<Team>teamOptional = teamRepository.findById(teamId);
-        Team team = teamOptional.orElseThrow(()->
+        Optional<Team> teamOptional = teamRepository.findById(teamId);
+        Team team = teamOptional.orElseThrow(() ->
                 new RestApiException(ErrorType.NOT_FOUND_TEAM));
 
         Optional<TeamUserRelation> teamUserRelationOptional = teamUserRepository.findByUserAndTeam(user, team);
-        if(teamUserRelationOptional.isPresent())
-        {
-            TeamUserRelation teamUserRelation = teamUserRelationOptional.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_RELATION));
-            if (teamUserRelation.getIsWriter())
-            {
+        if (teamUserRelationOptional.isPresent()) {
+            TeamUserRelation teamUserRelation = teamUserRelationOptional.orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_RELATION));
+            if (teamUserRelation.getIsWriter()) {
                 teamRepository.delete(team);
 
+            } else {
+                return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, "유저의 권한이 없습니다."));
             }
-            else{
-                return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE,"유저의 권한이 없습니다."));
-            }
-        }
-        else{
-            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_FOUND,"유저가 속한 팀이 아닙니다."));
+        } else {
+            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_FOUND, "유저가 속한 팀이 아닙니다."));
         }
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"팀 구인글 삭제완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 삭제완료"), null);
 
     }
 
@@ -292,8 +287,7 @@ public class TeamService {
     // 유저 정보 리스트를 가져오고 여기에는 유저의 이름, id, 한줄소개가 있어야한다.
     // 공모전글을 등록할때 내 친구들만 데이터를 가져오는 API
     @Transactional
-    public ApiResponseDto<FriendShipSearchResponseDto> getfriendRegister(String keyword, UserDetails loginUser,int pageNo, int pageSize, String sortBy)
-    {
+    public ApiResponseDto<FriendShipSearchResponseDto> getfriendRegister(String keyword, UserDetails loginUser, int pageNo, int pageSize, String sortBy) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(sortBy).descending());
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
@@ -304,12 +298,10 @@ public class TeamService {
         // 각각의 friendshipe에 대해서 user가 아닌 user에 대한 정보를 저장하고 리스트로 만들어준다
 
         List<UserSimpleDto> userSimpleDtoList = new ArrayList<>();
-        for(FriendShip friendShip:friendShipList)
-        {
+        for (FriendShip friendShip : friendShipList) {
             User user1 = friendShip.getUser1();
             User user2 = friendShip.getUser2();
-            if (user1 == user)
-            {
+            if (user1 == user) {
                 UserSimpleDto userSimpleDto = new UserSimpleDto();
                 userSimpleDto.setUserProfile(user2.getUserProfile());
                 userSimpleDto.setUserKoreaName(user2.getUserKoreaName());
@@ -317,8 +309,7 @@ public class TeamService {
                 userSimpleDto.setUserId(user2.getId());
                 userSimpleDtoList.add(userSimpleDto);
 
-            }
-            else {
+            } else {
                 UserSimpleDto userSimpleDto = new UserSimpleDto();
                 userSimpleDto.setUserProfile(user1.getUserProfile());
                 userSimpleDto.setUserKoreaName(user1.getUserKoreaName());
@@ -334,8 +325,9 @@ public class TeamService {
         friendShipSearchResponseDto.setTotalPages(friendShips.getTotalPages());
         friendShipSearchResponseDto.setPageNo(pageNo);
         friendShipSearchResponseDto.setTotalElements(friendShips.getTotalElements());
-     return ResponseUtils.ok(friendShipSearchResponseDto, null)  ;
+        return ResponseUtils.ok(friendShipSearchResponseDto, null);
     }
+
     // 내가 만든 팀에 대한 정보를 모두 가져온다
     @Transactional
     public ApiResponseDto<TeamApplyDto> getTeamApplyTotal(UserDetails loginUser) {
@@ -383,7 +375,7 @@ public class TeamService {
                 teamAbstractDto1.setTeamPoster(team2.getCompetition().getCompetitionPoster());
                 teamAbstractDto1.setTeamLocations(locationList1);
                 List<String> PositionList1 = new ArrayList<>();
-                List<Position> positionList= teamPositionRelationRepository.findByTeam(team2);
+                List<Position> positionList = teamPositionRelationRepository.findByTeam(team2);
                 for (Position position : positionList) {
                     PositionList1.add(position.getPositionName());
                 }
@@ -397,6 +389,7 @@ public class TeamService {
         }
         return ResponseUtils.ok(teamApplyDto, null);
     }
+
     @Transactional
     // 타입에 따라 내가 만든 팀의 정보를 가져온다
     public ApiResponseDto<TeamListDto> getTeamApplyType(UserDetails loginUser, int pageNo, int pageSize, String sortBy, String type) {
@@ -439,7 +432,7 @@ public class TeamService {
                     teamAbstractDto.setTeamPoster(team.getCompetition().getCompetitionPoster());
                     teamAbstractDto.setTeamLocations(locationList);
                     List<String> PositionList = new ArrayList<>();
-                    List<Position> positionList= teamPositionRelationRepository.findByTeam(team);
+                    List<Position> positionList = teamPositionRelationRepository.findByTeam(team);
                     for (Position position : positionList) {
                         PositionList.add(position.getPositionName());
                     }
@@ -458,11 +451,11 @@ public class TeamService {
 
         return ResponseUtils.ok(teamListDto, null);
     }
+
     // 팀의 상태(진행/완료)를 수정한다
     @Transactional
-    public ApiResponseDto<SuccessResponse> teamStatus(UserDetails loginUser, Long team_id, TeamStatusDto teamStatusDto)
-    {
-        Optional<Team> teamOptional  = teamRepository.findById(team_id);
+    public ApiResponseDto<SuccessResponse> teamStatus(UserDetails loginUser, Long team_id, TeamStatusDto teamStatusDto) {
+        Optional<Team> teamOptional = teamRepository.findById(team_id);
         Team team = teamOptional.orElseThrow(
                 () -> new RestApiException(ErrorType.NOT_FOUND_TEAM)
         );
@@ -473,15 +466,12 @@ public class TeamService {
         TeamUserRelation teamUserRelation = teamUserRelationOptional.orElseThrow(
                 () -> new RestApiException(ErrorType.NOT_FOUND_USER_TEAM)
         );
-        if(teamUserRelation.getIsWriter()==true)
-        {
+        if (teamUserRelation.getIsWriter() == true) {
             team.setTeamStatus(teamStatusDto.getTeamStatus());
             teamRepository.save(team);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 공고글 상태 변경완료"),null);
-        }
-        else
-        {
-            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE,"권한이 없습니다"));
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 공고글 상태 변경완료"), null);
+        } else {
+            return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, "권한이 없습니다"));
         }
     }
 
@@ -511,7 +501,7 @@ public class TeamService {
 
         // 팀(모집 공고)
 
-        List<Position> positionList = team.getPositionList();
+        List<Position> positionList = teamPositionRelationRepository.findByTeam(team);
         List<PositionDto> positionDtoList = new ArrayList<>();
         for (Position position : positionList) {
             PositionDto positionDto = PositionDto.builder()
@@ -546,9 +536,15 @@ public class TeamService {
         for (Apply apply : applyList) {
             if (apply.getApplyStatus() == ApplyStatus.WAITING) { // 대기 중인 지원서만 가져옴
                 User applyUser = apply.getUser();
+                Profile userProfile = applyUser.getUserProfile();
+
+                ProfileDto profileDto = ProfileDto.builder()
+                        .ProfileId(userProfile.getProfileId())
+                        .ProfileUrl(userProfile.getProfielUrl()).build();
+
                 UserApplyDto userApplyDto = new UserApplyDto();
                 userApplyDto.setUserId(applyUser.getId());
-                userApplyDto.setUserProfile(applyUser.getUserProfile());
+                userApplyDto.setUserProfile(profileDto);
                 userApplyDto.setUserKoreaName(applyUser.getUserKoreaName());
                 userApplyDto.setUserRepresentativeProfileSentence(applyUser.getUserRepresentativeProfileSentence());
 
@@ -563,14 +559,10 @@ public class TeamService {
             }
         }
 
-        System.out.println("***********표시1***************");
-
         // 반환 데이터
         TeamApplyListDto teamApplyListDto = new TeamApplyListDto();
         teamApplyListDto.setTeam(simpleTeamDto);
         teamApplyListDto.setApplyList(userApplyDtoList);
-
-        System.out.println("***************표시2***************");
 
         return ResponseUtils.ok(teamApplyListDto, null);
     }

--- a/src/main/java/com/PuzzleU/Server/university/entity/University.java
+++ b/src/main/java/com/PuzzleU/Server/university/entity/University.java
@@ -3,6 +3,7 @@ package com.PuzzleU.Server.university.entity;
 import com.PuzzleU.Server.common.enumSet.UniversityType;
 import com.PuzzleU.Server.major.entity.Major;
 import com.PuzzleU.Server.relations.entity.UserUniversityRelation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,9 +30,11 @@ public class University {
     @Column(length = 15)
     private String universityName;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "university",cascade = CascadeType.REMOVE)
     private List<Major> major = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "university", cascade = CascadeType.REMOVE)
     private List<UserUniversityRelation> userUniversities = new ArrayList<>();
 }

--- a/src/main/java/com/PuzzleU/Server/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/PuzzleU/Server/user/dto/KakaoUserInfoDto.java
@@ -7,6 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 @Builder
+@Getter
 public class KakaoUserInfoDto {
     private String kakaoId;
     private String nickname;

--- a/src/main/java/com/PuzzleU/Server/user/entity/User.java
+++ b/src/main/java/com/PuzzleU/Server/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.PuzzleU.Server.user.entity;
 
 import com.PuzzleU.Server.apply.entity.Apply;
-import com.PuzzleU.Server.common.enumSet.UniversityStatus;
 import com.PuzzleU.Server.common.enumSet.UserRoleEnum;
 import com.PuzzleU.Server.common.enumSet.WorkType;
 import com.PuzzleU.Server.experience.entity.Experience;
@@ -10,12 +9,13 @@ import com.PuzzleU.Server.heart.entity.Heart;
 import com.PuzzleU.Server.major.entity.Major;
 import com.PuzzleU.Server.position.entity.Position;
 import com.PuzzleU.Server.profile.entity.Profile;
-import com.PuzzleU.Server.relations.entity.UserInterestRelation;
-import com.PuzzleU.Server.relations.entity.UserLocationRelation;
-import com.PuzzleU.Server.relations.entity.UserSkillsetRelation;
-import com.PuzzleU.Server.relations.entity.UserUniversityRelation;
+import com.PuzzleU.Server.relations.entity.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,14 +49,17 @@ public class User {
     @Column(nullable = true, length = 6)
     private String userKoreaName;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_profile_id",nullable = true)
     private Profile userProfile;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_position_id1")
     private Position userPosition1;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_position_id2")
     private Position userPosition2;
@@ -78,39 +81,51 @@ public class User {
 
 
 
-
+    @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<UserUniversityRelation> userUniversities = new ArrayList<>();
 
-
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="major_id")
     private Major major;
 
-
+    @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<UserInterestRelation> userInterestRelations = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserLocationRelation> userLocationRelations = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<UserSkillsetRelation> userSkillsetRelations = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<Experience> experience = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user1",cascade = CascadeType.REMOVE)
     private List<FriendShip> friendShip1 = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user2",cascade = CascadeType.REMOVE)
     private List<FriendShip> friendShip2 = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
     private List<Heart> hearts = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Apply> applies = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<TeamUserRelation> teamUserRelations = new ArrayList<>();
+
     @Builder
     public User(
             Long id,


### PR DESCRIPTION
## 지원자 보기 - 대기 중인 지원자 기능 구현
상세 정보: https://www.notion.so/e9bc0e16f9814f29885049c9baff6422

## 지원자 수락/거절 기능 구현
상세 정보: https://www.notion.so/ba9384cabade446db45103efbee656ed

## 연관관계 매핑 컬럼에 모두 @JsonIgnore 추가
에러 해결하다가 fetchType을 Lazy로 한 경우에 순환참조가 발생하면서 에러가 날 수 있다고 해서 모든 연관관계 매핑 컬럼에 @JsonIgore를 추가했습니다. (참고: https://data-make.tistory.com/727)
결론적으로 순환 참조 문제가 에러의 근본적인 원인은 아니었지만(ㅠㅠ) @JsonIgnore를 붙여놔서 나쁠 게 없을 것 같아서 일단 지우지 않고 놔뒀습니다.

## ApplyStatus: FINISHED -> ACCEPTED, REJECTED
: 원래 완료(FINISHED)가 있었는데, FINISHED가 수락과 거절로 나눠질 것 같아서 ApplyStatus enum을  WAITING, FINISHED, CANCEL에서 WAITING, ACCEPTED, REJECTED, CANCEL로 바꿨습니다.

```
public enum ApplyStatus {
    WAITING, FINISHED, CANCEL // 대기, 완료, 취소
}
```
```
public enum ApplyStatus {
    WAITING, ACCEPTED, REJECTED, CANCEL // 대기, 수락, 거절, 취소
}
```

이렇게 바꾸니까 성현님이 만든 getApplyType 부분에서 에러가 나서 수정했는데(ApplyRepository에서 FINISHED 받아오는 부분을 ACCEPTED/REJECTED 받아오는 걸로 수정함), 그 부분 제가 제대로 이해하고 수정한 게 맞는지 확인 부탁드립니다.