### PR TITLE
[FIX] 일부 api 수정

### DIFF
--- a/src/main/java/com/PuzzleU/Server/apply/controller/ApplyController.java
+++ b/src/main/java/com/PuzzleU/Server/apply/controller/ApplyController.java
@@ -25,7 +25,7 @@ public class ApplyController {
     }
 
     @GetMapping("/{applyId}")
-    public ApiResponseDto<ApplyDetailDto> applyDetail(@PathVariable Long applyId) {
-        return applyService.applyDetail(applyId);
+    public ApiResponseDto<ApplyDetailDto> applyDetail(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long applyId) {
+        return applyService.applyDetail(loginUser, applyId);
     }
 }

--- a/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
+++ b/src/main/java/com/PuzzleU/Server/apply/dto/UserApplyDto.java
@@ -1,5 +1,6 @@
 package com.PuzzleU.Server.apply.dto;
 
+import com.PuzzleU.Server.common.enumSet.ApplyStatus;
 import com.PuzzleU.Server.profile.dto.ProfileDto;
 import lombok.*;
 
@@ -16,4 +17,5 @@ public class UserApplyDto {
 
     private Long ApplyId;
     private String ApplyTitle;
+    private ApplyStatus applyStatus;
 }

--- a/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
+++ b/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
@@ -91,12 +91,25 @@ public class ApplyService {
 
     // 지원서 상세
     @Transactional
-    public ApiResponseDto<ApplyDetailDto> applyDetail(Long applyId) {
+    public ApiResponseDto<ApplyDetailDto> applyDetail(UserDetails loginUser, Long applyId) {
 
         Apply apply = applyRepository.findByApplyId(applyId)
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_APPLY));
 
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+
+
         Team team = apply.getTeam();
+
+        TeamUserRelation teamUserRelation = teamUserRepository.findByUserAndTeam(user, team)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_RELATION));
+
+        // 로그인한 유저가 모집 공고의 작성자여야 지원서 상세 열람 가능
+        if (teamUserRelation.getIsWriter() == false) {
+            throw new RestApiException(ErrorType.NO_PERMISSION_TO_APPLICATION);
+        }
 
         Competition competition  = team.getCompetition();
 

--- a/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
+++ b/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
@@ -65,6 +65,13 @@ public class ApplyService {
         User user = userRepository.findByUsername(loginUser.getUsername())
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
 
+        List<Apply> applyList = user.getApplies();
+        for (Apply a : applyList) {
+            if (a.getTeam() == team) {
+                throw new RestApiException(ErrorType.ALREADY_SUBMIT_APPLY);
+            }
+        }
+
         Apply apply = Apply.builder()
                 .applyTitle(applyPostDto.getApplyTitle())
                 .applyContent(applyPostDto.getApplyContent())

--- a/src/main/java/com/PuzzleU/Server/common/config/WebMvcConfig.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.PuzzleU.Server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowedMethods("OPTIONS","GET","POST","PUT","DELETE");
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -46,7 +46,8 @@ public enum ErrorType {
     NO_PERMISSION_TO_APPLICATION_LIST(403, "지원서 리스트를 열람할 권한이 없습니다."),
     NO_PERMISSION_TO_APPLICATION(403, "지원서를 열람할 권한이 없습니다."),
     NOT_MATCH_ACCEPT_REJECT(400, "요청값을 확인하세요. ACCEPT 또는 REJECT로만 요청 가능합니다."),
-    NO_PERMISSION_TO_ACCEPT_APPLY(403, "지원서를 수락 또는 거절할 권한이 없습니다.");
+    NO_PERMISSION_TO_ACCEPT_APPLY(403, "지원서를 수락 또는 거절할 권한이 없습니다."),
+    ALREADY_SUBMIT_APPLY(400, "이미 지원서를 제출했습니다. 한 팀 당 하나의 지원서만 제출 가능합니다.");
 
 
     private int code;

--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -44,6 +44,7 @@ public enum ErrorType {
     POSITION_NOT_PROVIDED(400, "포지션이 입력되지 않았습니다."),
     FOUND_LIKE(400, "이미 좋아요를 눌렀습니다"),
     NO_PERMISSION_TO_APPLICATION_LIST(403, "지원서 리스트를 열람할 권한이 없습니다."),
+    NO_PERMISSION_TO_APPLICATION(403, "지원서를 열람할 권한이 없습니다."),
     NOT_MATCH_ACCEPT_REJECT(400, "요청값을 확인하세요. ACCEPT 또는 REJECT로만 요청 가능합니다."),
     NO_PERMISSION_TO_ACCEPT_APPLY(403, "지원서를 수락 또는 거절할 권한이 없습니다.");
 

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -534,7 +534,7 @@ public class TeamService {
         List<Apply> applyList = team.getApplyList();
         List<UserApplyDto> userApplyDtoList = new ArrayList<>();
         for (Apply apply : applyList) {
-            if (apply.getApplyStatus() == ApplyStatus.WAITING) { // 대기 중인 지원서만 가져옴
+            if (apply.getApplyStatus() != ApplyStatus.CANCEL) { // 취소된 지원서는 받아오지 않음
                 User applyUser = apply.getUser();
                 Profile userProfile = applyUser.getUserProfile();
 
@@ -550,6 +550,7 @@ public class TeamService {
 
                 userApplyDto.setApplyId(apply.getApplyId());
                 userApplyDto.setApplyTitle(apply.getApplyTitle());
+                userApplyDto.setApplyStatus(apply.getApplyStatus());
 
                 userApplyDtoList.add(userApplyDto);
 

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -555,8 +555,6 @@ public class TeamService {
                 userApplyDtoList.add(userApplyDto);
 
                 System.out.println(apply.getApplyTitle());
-
-
             }
         }
 


### PR DESCRIPTION
## 지원서 상세 열람 권한 설정
특정 지원서에 대한 상세 내용을 팀 모집글 작성자만 열람 가능하게 막아두었습니다.

## 대기중인 지원자
기존의 "WAITING"인 지원서 리스트만 반환하는 것에서, 팀에 대한 모든 지원서를 반환하되, 지원서 상태(WAITING, ACCEPTED, REJECTED)를 반환하는 것으로 변경
-> 상태가 CANCEL인 지원서는 디비 상에만 존재하는 거라고 생각해서, 리스트에 안 나오게 했습니다.

## WebMvcConfig 생성
배포 후 CORS 에러가 나지 않도록 WebMvcConfig 파일을 생성했습니다. (Spring과 Swift가 통신할 때도 CORS 에러가 발생하는지는 모르겠지만, 혹시 몰라 추가해놓았어요. 일단 모든 요청에 대해 허용되게 해 놨는데, 보안을 위해 어느 정도 막아야 할 필요가 있다면 나중에 수정하도록 하겠습니다.)

## 한 팀에 대해 지원 한 번만 가능하게 수정
지원서 제출 매서드에 대해서, 중복 지원 불가능하게 막았습니다. (한 팀에 대해서 하나의 지원서만 제출 가능)
