### PR TITLE
[FEAT] 중복 지원 여부, 정보 수신 동의 기능 구현

### DIFF
--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -8,6 +8,7 @@ public enum ErrorType {
     NOT_VALID_CLIENT(400, "애플 로그인 Feign API Clinet 호출 오류"),
     NOT_WRITER(400, "작성자만 삭제/수정할 수 있습니다."),
     DUPLICATED_USERNAME(400, "중복된 username 입니다."),
+    DUPLICATED_PUZZLE_ID(400, "중복된 퍼즐 ID 입니다."),
     NOT_MATCHING_INFO(400, "회원을 찾을 수 없습니다."),
     NOT_MATCHING_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
     NOT_FOUND_USER(400, "사용자가 존재하지 않습니다."),

--- a/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
@@ -256,6 +256,12 @@ public class UserController {
         return universityService.getUniversityList(loginUser);
     }
 
+    @PatchMapping("/essential/consent")
+    public ApiResponseDto<SuccessResponse> updateConsentMarketing(@AuthenticationPrincipal UserDetails loginUser, @RequestBody ConsentMarketingDto consentMarketingDto) {
+        return userService.updateConsentMarketing(loginUser, consentMarketingDto);
+
+    }
+
 
 
 }

--- a/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
+++ b/src/main/java/com/PuzzleU/Server/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.experience.dto.ExperienceDto;
 import com.PuzzleU.Server.friendship.dto.FriendShipSearchResponseDto;
 import com.PuzzleU.Server.friendship.service.FriendshipService;
-import com.PuzzleU.Server.relations.dto.UserSkillsetRelationDto;
 import com.PuzzleU.Server.relations.dto.UserSkillsetRelationListDto;
 import com.PuzzleU.Server.skillset.dto.SkillSetListDto;
 import com.PuzzleU.Server.experience.service.ExperienceService;
@@ -137,6 +136,12 @@ public class UserController {
     ) {
         return userService.registerEssential(loginUser, userRegisterEssentialDto);
     }
+
+    @GetMapping("/essential/puzzleId")
+    public ApiResponseDto<SuccessResponse> getPuzzleIdDuplicate(@RequestParam(value = "id", required = true) String puzzleId) {
+        return userService.getPuzzleIdDuplicate(puzzleId);
+    }
+
     @GetMapping("/friendSearch")
     public ApiResponseDto<FriendShipSearchResponseDto> searchUser(
             @Valid

--- a/src/main/java/com/PuzzleU/Server/user/dto/ConsentMarketingDto.java
+++ b/src/main/java/com/PuzzleU/Server/user/dto/ConsentMarketingDto.java
@@ -1,0 +1,13 @@
+package com.PuzzleU.Server.user.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@Getter
+public class ConsentMarketingDto {
+    private Boolean consentMarketing;
+}

--- a/src/main/java/com/PuzzleU/Server/user/entity/User.java
+++ b/src/main/java/com/PuzzleU/Server/user/entity/User.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +41,10 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
 
+    // 혜택 수신 동의
+    @Column(nullable = true)
+    @ColumnDefault("false")
+    private Boolean consentMarketing;
 
     // 필수 정보
 

--- a/src/main/java/com/PuzzleU/Server/user/repository/UserRepository.java
+++ b/src/main/java/com/PuzzleU/Server/user/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM users u WHERE u!=:user")
     List<User> findAllExcept(User user, Pageable pageable);
 
+    Optional<User> findByUserPuzzleId(String puzzleId);
+
 }

--- a/src/main/java/com/PuzzleU/Server/user/service/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/user/service/UserService.java
@@ -314,6 +314,19 @@ public class UserService {
 
         return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 필수 정보 저장 완료"), null);
     }
+
+    // 회원가입 시 퍼즐 ID 중복 여부 반환
+    public ApiResponseDto<SuccessResponse> getPuzzleIdDuplicate(String puzzleId) {
+        Optional<User> userOptional = userRepository.findByUserPuzzleId(puzzleId);
+
+        if (userOptional.isPresent()) {
+            throw new RestApiException(ErrorType.DUPLICATED_PUZZLE_ID);
+        }
+
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "사용할 수 있는 퍼즐 ID입니다."), null);
+
+    }
+
     @Transactional
     // 모든 멤버들을 검색할 수 있는 API
     public ApiResponseDto<FriendShipSearchResponseDto> searchUser(int pageNo, int pageSize, String sortBy, String keyword) {

--- a/src/main/java/com/PuzzleU/Server/user/service/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/user/service/UserService.java
@@ -46,9 +46,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -663,6 +665,17 @@ public class UserService {
         userProfileDto.setSkillsetList(userProfileSkillsetDtoList);
 
         return ResponseUtils.ok(userProfileDto, null);
+    }
+
+    // 정보 수신 여부 동의 수정
+    public ApiResponseDto<SuccessResponse> updateConsentMarketing(UserDetails loginUser, ConsentMarketingDto consentMarketingDto) {
+        User user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        user.setConsentMarketing(consentMarketingDto.getConsentMarketing());
+        userRepository.save(user);
+
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "정보 수신 여부 저장 완료"), null);
     }
 
 }


### PR DESCRIPTION
## 퍼즐 ID 중복 지원 여부 확인 기능 구현
회원가입 필수 정보 입력시, 퍼즐 ID 입력하는 부분에서 이미 있는 ID인지 아닌지 확인해야 하기 때문에, 해당 정보를 확인할 수 있는 기능을 구현했습니다. (이미 있는 ID인 경우, 400 에러)

## 회원가입 정보 수신 동의 기능 구현
저번에 기획에 선택 동의가 피그마에 있는 거 하나냐고 물어봤을 때 아직 확정이 아니라고 하셨었는데, 일단 하나라고 생각하고 구현해놨습니다. 기획 수정되면 나중에 코드 수정하겠습니다.