### PR TITLE
[FIX] 카카오 로그인 수정

### DIFF
--- a/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
+++ b/src/main/java/com/PuzzleU/Server/common/enumSet/ErrorType.java
@@ -51,7 +51,9 @@ public enum ErrorType {
     ALREADY_REGISTERED(400, "이미 지원한 공모전입니다"),
     NOT_ALLOWED_YEAR(400, "졸업예정 년도가 입학년도보다 빠를 순 없습니다"),
     ALREADY_SUBMIT_APPLY(400, "이미 지원서를 제출했습니다. 한 팀 당 하나의 지원서만 제출 가능합니다."),
-    ALREADY_REGISTERED_FRIEND(400, "이미 친구 신청을 한 상태입니다");
+    ALREADY_REGISTERED_FRIEND(400, "이미 친구 신청을 한 상태입니다"),
+    ACCESS_TOKEN_NOT_EXPIRED(401, "만료되지 않은 엑세스 토큰입니다."),
+    REFRESH_TOKEN_NOT_VALIDATE(401, "리프레시 토큰이 유효하지 않습니다.");
 
 
 

--- a/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
+++ b/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
@@ -101,6 +101,7 @@ public class JwtUtil {
             log.info("Invalid JWT signature, 유효하지 않은 JWT 서명");
         }catch (ExpiredJwtException e){
             log.info("Expired JWT token, 만료된 JWT token 입니다");
+            return false; // 만료된 토큰이면 return false
         }catch (UnsupportedJwtException e)
         {
             log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
@@ -116,6 +117,7 @@ public class JwtUtil {
     {
         String cleanToken = token.replace(BEARER_PREFIX, "");
 //        System.out.println("getUserInfoFromToken token: " + cleanToken);
+
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(cleanToken).getBody();
         
 //        // jwt 파싱하기 위한 빌더 객체 생성 / 토큰의 서명 검증을 위해 사용할 키 설정 / 파싱 생성 / 토큰을 파싱하고 클레임을 가져옴 / 토큰의 본문을 반환
@@ -169,5 +171,6 @@ public class JwtUtil {
 
         return newAccessToken;
     }
+
 }
 

--- a/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
+++ b/src/main/java/com/PuzzleU/Server/common/jwt/JwtUtil.java
@@ -34,7 +34,11 @@ public class JwtUtil {
     private static final String BEARER_PREFIX = "Bearer ";
 
     // 60 더 곱했습니다
-    private static final long TOKEN_TIME = 60*60*60 * 60 * 1000L;
+    private static final long TOKEN_TIME = 60*60*60 * 60 * 1000L; // 60 days
+
+    // accress token과 refresh token 구분을 위한 time 설정
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 15; // 15 minutes
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7; // 7 days
 
     @Value("${JWT_TOKEN}")
     private String secretKey;
@@ -126,4 +130,44 @@ public class JwtUtil {
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
+    // access token과 refresh token을 구분해서 생성
+    // Access Token 생성
+    public String createAccessToken(String username, UserRoleEnum role) {
+        return createTokenBase(username, role, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(String username, UserRoleEnum role) {
+        return createTokenBase(username, role, REFRESH_TOKEN_EXPIRATION_TIME);
+    }
+
+    // 토큰 생성
+    private String createTokenBase(String username, UserRoleEnum role, long expirationTime) {
+        Date date = new Date();
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .claim(AUTHORIZATION_KEY, role)
+                        .setExpiration(new Date(date.getTime() + expirationTime))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    // refresh 토큰으로 access 토큰 재발급
+    public String refreshAccessToken(String refreshToken) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(refreshToken)
+                .getBody();
+
+        String username = claims.getSubject();
+        UserRoleEnum role = (UserRoleEnum) claims.get(AUTHORIZATION_KEY);
+
+        // 기존 토큰의 정보를 바탕으로 새로운 access token 생성
+        String newAccessToken = createAccessToken(username, role);
+
+        return newAccessToken;
+    }
 }
+

--- a/src/main/java/com/PuzzleU/Server/common/jwt/TokenDto.java
+++ b/src/main/java/com/PuzzleU/Server/common/jwt/TokenDto.java
@@ -1,0 +1,15 @@
+package com.PuzzleU.Server.common.jwt;
+
+import lombok.*;
+
+@Getter
+@Data
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+    private String message;
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/PuzzleU/Server/common/oauth/OAuthController.java
+++ b/src/main/java/com/PuzzleU/Server/common/oauth/OAuthController.java
@@ -1,7 +1,6 @@
 package com.PuzzleU.Server.common.oauth;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
-import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.jwt.TokenDto;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +28,14 @@ public class OAuthController {
 //        System.out.println("kakaoUserInfo = " + kakaoUserInfoDto.toString());
 
         return oAuthService.kakaoLogin(code);
+    }
+
+    @PostMapping("/kakao/refresh")
+    public ApiResponseDto<TokenDto> refreshToken(
+            @RequestHeader(value="accessToken") String accessToken,
+            @RequestHeader(value="refreshToken") String refreshToken
+    ) {
+        return oAuthService.refreshKakaoToken(accessToken, refreshToken);
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/common/oauth/OAuthController.java
+++ b/src/main/java/com/PuzzleU/Server/common/oauth/OAuthController.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.common.oauth;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
 import com.PuzzleU.Server.common.api.SuccessResponse;
+import com.PuzzleU.Server.common.jwt.TokenDto;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +19,7 @@ public class OAuthController {
      */
 
     @GetMapping("/kakao")
-    public ApiResponseDto<SuccessResponse> kakaoLogin(@RequestParam("code") String code) {
+    public ApiResponseDto<TokenDto> kakaoLogin(@RequestParam("code") String code) {
 //        System.out.println("code = " + code); // 카카오 로그인을 수행하면 /api/oauth/kakao로 리다이렉트 되면서 code가 받아와짐
 //
 //        String accessToken = oAuthService.getKakaoAccessToken(code); // access token 받아오기
@@ -29,4 +30,5 @@ public class OAuthController {
 
         return oAuthService.kakaoLogin(code);
     }
+
 }

--- a/src/main/java/com/PuzzleU/Server/common/oauth/OAuthService.java
+++ b/src/main/java/com/PuzzleU/Server/common/oauth/OAuthService.java
@@ -224,6 +224,7 @@ public class OAuthService {
 
             // refresh token을 DB에 저장
             user.get().setKakaoRefreshToken(refreshToken);
+            userRepository.save(user.get());
 
             // response 생성
             tokenDto.setMessage("카카오 로그인 성공");

--- a/src/main/java/com/PuzzleU/Server/common/oauth/OAuthService.java
+++ b/src/main/java/com/PuzzleU/Server/common/oauth/OAuthService.java
@@ -2,7 +2,8 @@ package com.PuzzleU.Server.common.oauth;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
 import com.PuzzleU.Server.common.api.ResponseUtils;
-import com.PuzzleU.Server.common.api.SuccessResponse;
+import com.PuzzleU.Server.common.enumSet.ErrorType;
+import com.PuzzleU.Server.common.exception.RestApiException;
 import com.PuzzleU.Server.common.jwt.TokenDto;
 import com.PuzzleU.Server.user.dto.KakaoUserInfoDto;
 import com.PuzzleU.Server.user.entity.User;
@@ -11,9 +12,10 @@ import com.PuzzleU.Server.common.jwt.JwtUtil;
 import com.PuzzleU.Server.user.repository.UserRepository;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.jsonwebtoken.Claims;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -167,6 +169,7 @@ public class OAuthService {
         return kakaoUserInfoDto;
     }
 
+    @Transactional
     // 카카오 로그인 매서드
     public ApiResponseDto<TokenDto> kakaoLogin(String code) {
         /*
@@ -194,26 +197,74 @@ public class OAuthService {
             // 입력한 username, password, admin 으로 user 객체 만들어 repository 에 저장
             UserRoleEnum role = UserRoleEnum.USER; // 카카오 유저 ROLE 임의 설정
             User signUpUser = User.of(username, password, role);
-            userRepository.save(signUpUser);
 
             // 토큰 생성
-
             TokenDto tokenDto = new TokenDto();
 
-            tokenDto.setMessage("회원가입 성공");
-            tokenDto.setAccessToken(jwtUtil.createAccessToken(signUpUser.getUsername(), signUpUser.getRole()));
-            tokenDto.setRefreshToken(jwtUtil.createRefreshToken(signUpUser.getUsername(), signUpUser.getRole()));
+            String accessToken = jwtUtil.createAccessToken(signUpUser.getUsername(), signUpUser.getRole());
+            String refreshToken = jwtUtil.createRefreshToken(signUpUser.getUsername(), signUpUser.getRole());
+
+            // refresh token을 DB에 저장
+            signUpUser.setKakaoRefreshToken(refreshToken);
+            userRepository.save(signUpUser);
+
+            // response 생성
+            tokenDto.setMessage("카카오 회원가입 성공");
+            tokenDto.setAccessToken(accessToken);
+            tokenDto.setRefreshToken(refreshToken);
 
             return ResponseUtils.ok(tokenDto, null);
 
         } else { // DB에 존재하면 로그인 수행
+            // 토큰 생성
             TokenDto tokenDto = new TokenDto();
 
-            tokenDto.setMessage("로그인 성공");
-            tokenDto.setAccessToken(jwtUtil.createAccessToken(user.get().getUsername(), user.get().getRole()));
-            tokenDto.setRefreshToken(jwtUtil.createRefreshToken(user.get().getUsername(), user.get().getRole()));
+            String accessToken = jwtUtil.createAccessToken(user.get().getUsername(), user.get().getRole());
+            String refreshToken = jwtUtil.createRefreshToken(user.get().getUsername(), user.get().getRole());
+
+            // refresh token을 DB에 저장
+            user.get().setKakaoRefreshToken(refreshToken);
+
+            // response 생성
+            tokenDto.setMessage("카카오 로그인 성공");
+            tokenDto.setAccessToken(accessToken);
+            tokenDto.setRefreshToken(refreshToken);
 
             return ResponseUtils.ok(tokenDto, null);
         }
+    }
+
+    // refresh token으로 access token 재발급
+    @Transactional
+    public ApiResponseDto<TokenDto> refreshKakaoToken(String accessTokenOrigin, String refreshTokenOrigin) {
+
+        String accessToken = accessTokenOrigin.substring(7);
+        String refreshToken = refreshTokenOrigin.substring(7);
+
+        // 아직 만료되지 않은 토큰으로는 refresh 할 수 없음
+        if(jwtUtil.validateToken(accessToken)) throw new RestApiException(ErrorType.ACCESS_TOKEN_NOT_EXPIRED);
+
+        Claims claims = jwtUtil.getUserInfoFromToken(refreshToken);
+        String username = claims.get("sub", String.class); // access token에서 username을 가져옴
+
+        System.out.println(username);
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        String kakaoRefreshToken = user.getKakaoRefreshToken();
+
+        if (!jwtUtil.validateToken(kakaoRefreshToken.substring(7)) || !refreshToken.equals(kakaoRefreshToken.substring(7))) {
+            throw new RestApiException(ErrorType.REFRESH_TOKEN_NOT_VALIDATE); // 만료되거나 일치하지 않는 리프레시 토큰은 에러처리
+        }
+
+        String newAccessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole());
+
+        TokenDto tokenDto = new TokenDto();
+        tokenDto.setMessage("access token 재발급 성공");
+        tokenDto.setAccessToken(newAccessToken);
+        tokenDto.setRefreshToken(refreshTokenOrigin);
+
+        return ResponseUtils.ok(tokenDto, null);
     }
 }

--- a/src/main/java/com/PuzzleU/Server/user/entity/User.java
+++ b/src/main/java/com/PuzzleU/Server/user/entity/User.java
@@ -42,6 +42,9 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
 
+    // 카카오 로그인 refresh 토큰
+    private String kakaoRefreshToken;
+
     // 혜택 수신 동의
     @Column(nullable = true)
     @ColumnDefault("false")


### PR DESCRIPTION
레퍼런스: https://dobi852.tistory.com/35, https://velog.io/@chuu1019/Access-Token과-Refresh-Token이란-무엇이고-왜-필요할까, https://velog.io/@songunnie/Project-Spring-Security-JWT-Refresh-Token-사용해보기

![image](https://github.com/PuzzleU/puzzle-Server/assets/128376848/1e11e5b4-4c87-4f3d-9592-2acf4eb8634f)


⇒ 다른 구조는 기존과 거의 동일, “유저 정보&JWT 토큰(access, refresh) 응답”만 다름. (즉, 기존에는 jwt 토큰을 하나만 발급했다면, 이제 access 토큰과 refresh 토큰을 각각 발급.

(카카오와 서버 통신에서도 code로 토큰 요청 안 하고, Access Token이랑 Refresh Token 유저 정보에 저장해놨다가 쓰는 방법도 있지만, 저 구조도에서도 굳이 그렇게 하고 있지는 않아서 저 부분은 기존 코드 그대로 뒀습니다.)

> 유효기간을 짧게 두면 사용자가 로그인을 자주 해야하므로 사용자 경험적으로 좋지 않고, 유효기간을 길게 두면 보안상 탈취 위험에서 벗어날 수 없다.
> 
> 
> **해결법은 유효기간이 다른 `JWT 토큰` 2개(`Acses Token`과 `Refresh Token`)을 두는 것이다.**
> 

!!! 결론적으로 !!!

1. 카카오 로그인([kauth.kakao.com/oauth/authorize?client_id=bdae78483f052375d4334586ceee5544&redirect_uri=http://localhost:8080/api/oauth/kakao&response_type=code](http://kauth.kakao.com/oauth/authorize?client_id=bdae78483f052375d4334586ceee5544&redirect_uri=http://localhost:8080/api/oauth/kakao&response_type=code)) → access token과 refresh token 발급
2. access token을 헤더에 넣어 사용자 인증 하다가, access token이 만료되어 에러가 뜨면, refresh token을 이용해 access token 재발급 (oauth/kakao/refresh) 받아서 발급 받은 access token으로 로그인 요청
3. refresh token도 만료되어 에러(403) 뜨면 재로그인 요청
4. 1부터 다시 반복

⇒ 요 부분은 지원님께 공유하겠습니다!

***📌 token 만료 기한***

- access token: 15분
- refresh token: 7일

지금 로직 자체는 문제 없는 것 같은데, OAuth2 안 쓰고 구현한 거라 좀 아쉽네요… 일단 배포하는 게 급하니까 가능하면 나중에 배포 후에 수정하거나 하겠습니당