### PR TITLE
[FEAT] S3 연동 및 관리자용 프로필/스킬셋 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 
 }
 

--- a/src/main/java/com/PuzzleU/Server/common/config/S3Config.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.PuzzleU.Server.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/PuzzleU/Server/common/config/WebSecurityConfig.java
@@ -57,6 +57,7 @@ public class WebSecurityConfig {
                                 .requestMatchers("/api/user/**", "/actuator/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**").permitAll()
                                 .requestMatchers("/swagger-ui/**").permitAll()
+                                .requestMatchers("/api/upload/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "api/splash").permitAll()
                                 .anyRequest().authenticated()
 

--- a/src/main/java/com/PuzzleU/Server/upload/controller/UploadController.java
+++ b/src/main/java/com/PuzzleU/Server/upload/controller/UploadController.java
@@ -1,0 +1,57 @@
+package com.PuzzleU.Server.upload.controller;
+
+import com.PuzzleU.Server.profile.entity.Profile;
+import com.PuzzleU.Server.profile.repository.ProfileRepository;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/upload")
+public class UploadController {
+
+    private final AmazonS3Client amazonS3Client;
+    private final ProfileRepository profileRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @PostMapping("/profile")
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+        try {
+            String fileName =file.getOriginalFilename();
+            String folder = "/profile"; // 저장할 폴더
+
+            String fileUrl= "https://" + bucket + ".s3." + region + ".amazonaws.com" + folder + "/" + fileName;
+            ObjectMetadata metadata= new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+            amazonS3Client.putObject(bucket + folder, fileName, file.getInputStream(), metadata);
+
+            Profile profile = new Profile();
+            profile.setProfielUrl(fileUrl);
+
+            profileRepository.save(profile);
+
+            return ResponseEntity.ok(fileUrl);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,16 @@ management:
     web:
       exposure:
         include: info, health
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    stack.auto: false
+    region.static: ${S3_REGION}
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_SECRET_KEY}
 #social-login.provider.apple.grant-type=authorization_code
 #social-login.provider.apple.client-id=YOUR_APPLE_CLIENT_ID
 #social-login.provider.apple.key-id=YOUR_APPLE_KEY_ID


### PR DESCRIPTION
## S3 연동
dependency 추가 및 yml 파일에서 S3 관련 설정 추가했습니다.

## S3 관련 환경 변수 추가
카톡으로 전달하겠습니다.

## profile 업로드 기능 구현
관리자가 업로드하는 용으로, 
/api/upload/profile에 post로 file 보내면 버킷(profile 폴더 내)에 업로드되고 해당 url이 DB에 저장됩니다.

## skillset 업로드 기능 구현
관리자가 업로드 하는 용으로,
/api/upload/skillset에 post로 file 보내면 버킷(profile 폴더 내)에 업로드되고 해당 url이 DB에 저장됩니다.

## 추후에 공모전 업로드하는 api도 추가 예정
관리자가 업로드 하는 용으로, postman에서 포스터 추가해서 업로드하면 된다고 기획 쪽에 전달하면 될 것 같아요.
(공모전, 스킬셋 외에 이미지 파일을 저장해야 하는 것이 더 있을까요?)

## 📌 전달 사항
- 배포 후에 온보딩부터 붙여본다고 해서, 프로필/스킬셋 먼저 만들었습니다. 추후에 공모전 업로드 api도 만들게요!
- profile은 DB에서 기존 데이터 다 지운 다음에 figma에 있는 프로필 12개 가져와서 S3 연동해서 넣어놨습니다.
- skillset은 DB는 안 갈고 잘 되는 거 테스트만 해봤어요. 스킬셋 로고-이름 리스트 기획팀에서 어느 정도 결정되거나 하면 그때 리스트 받아서 넣겠습니다. 배포 후에 iOS랑 붙이기 전에 넣어야 할 것 같아요.