### PR TITLE
[refactor] format_change

### DIFF
--- a/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
+++ b/src/main/java/com/PuzzleU/Server/apply/service/ApplyService.java
@@ -100,7 +100,7 @@ public class ApplyService {
             positionApplyRelationRepository.save(positionApplyRelation);
         }
         notificationService.sendApply(user,writer,"새로운 지원자가 있습니다", NotificationType.ApplyChange, team, competition);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 저장 완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 저장 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 지원서 상세
@@ -147,7 +147,7 @@ public class ApplyService {
                                                 .applyTitle(apply.getApplyTitle())
                                                         .applyContent(apply.getApplyContent()).build();
 
-        return ResponseUtils.ok(applyDetailDto, null);
+        return ResponseUtils.ok(applyDetailDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // type에 따라 내가 지원한 팀들을 볼 수 있는 기능
@@ -218,7 +218,7 @@ public class ApplyService {
         teamListDto.setPageSize(pageSize);
 
 
-        return ResponseUtils.ok(teamListDto, null);
+        return ResponseUtils.ok(teamListDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     // 내가 지원한 지원서나 팀을 볼 수 있음
     @Transactional
@@ -284,7 +284,7 @@ public class ApplyService {
                 applyTeamDto.setTeamListDto2(teamAbstractDto1);
             }
         }
-        return ResponseUtils.ok(applyTeamDto, null);
+        return ResponseUtils.ok(applyTeamDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     // 나의 지원을 삭제함
     @Transactional
@@ -299,7 +299,7 @@ public class ApplyService {
         if(apply.getUser() == user)
         {
             applyRepository.delete(apply);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 삭제완료"),null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 삭제완료"),ErrorResponse.builder().status(200).message("요청 성공").build());
         }
         else
         {

--- a/src/main/java/com/PuzzleU/Server/common/api/ResponseUtils.java
+++ b/src/main/java/com/PuzzleU/Server/common/api/ResponseUtils.java
@@ -6,11 +6,12 @@ import lombok.Getter;
 public class ResponseUtils {
     //d
     // 요청 성공인 경우
-    public static <T> ApiResponseDto<T> ok(T response, String jwt)
+    public static <T> ApiResponseDto<T> ok(T response, ErrorResponse errorResponse)
     {
         return ApiResponseDto.<T>builder()
                 .success(true)
                 .response(response)
+                .error(errorResponse)
                 .build();
     }
     // 에러가 발생한 경우

--- a/src/main/java/com/PuzzleU/Server/common/staticData/StaticDataService.java
+++ b/src/main/java/com/PuzzleU/Server/common/staticData/StaticDataService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.common.staticData;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.interest.dto.InterestTypeDto;
 import com.PuzzleU.Server.location.dto.LocationDto;
@@ -54,6 +55,6 @@ public class StaticDataService {
                 .locationList(locationList)
                 .profileList(profileList).build();
 
-        return ResponseUtils.ok(staticDataDto, null);
+        return ResponseUtils.ok(staticDataDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 }

--- a/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
+++ b/src/main/java/com/PuzzleU/Server/competition/service/CompetitionService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.competition.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.CompetitionType;
@@ -118,7 +119,7 @@ public class CompetitionService {
                 .collect(Collectors.toList());
 
         CompetitionHomeTotalDto competitionHomeTotalDto = new CompetitionHomeTotalDto(competitionHomePageDtos, pageNo, pageSize, competitionPage.getTotalElements(), competitionPage.getTotalPages(), competitionPage.isLast());
-        return ResponseUtils.ok(competitionHomeTotalDto, null);
+        return ResponseUtils.ok(competitionHomeTotalDto, ErrorResponse.builder().status(200).message("성공").build());
     }
 
     // 공모전 하나의 정보를 전체다 볼 수 있는 API
@@ -149,7 +150,7 @@ public class CompetitionService {
                 });
         competitionRepository.updateVisit(competitionId);
 
-        return ResponseUtils.ok(competitionSpecificDto, null);
+        return ResponseUtils.ok(competitionSpecificDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     // 최신순, 마감빠른순, 마감느린순, 인기순, 조회순, 팀빌딩순
 

--- a/src/main/java/com/PuzzleU/Server/experience/service/ExperienceService.java
+++ b/src/main/java/com/PuzzleU/Server/experience/service/ExperienceService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.experience.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.ErrorType;
@@ -48,7 +49,7 @@ public class ExperienceService {
                 .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
         Experience experience = new Experience(experienceDto.getExperienceName(),experienceDto.getExperienceType(),experienceDto.getExperienceStartYear(),experienceDto.getExperienceStartMonth(),experienceDto.getExperienceEndYear(),experienceDto.getExperienceEndMonth(),experienceDto.getExperienceStatus(),experienceDto.getExperienceRole(),user);
         experienceRepository.save(experience);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 저장완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 저장완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     // 유저의 경험을 수정하는 API
     public ApiResponseDto<SuccessResponse> updateExperience(
@@ -98,7 +99,7 @@ public class ExperienceService {
         }
 
         experienceRepository.save(experience);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 수정완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 수정완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
     // 유저의 경험을 삭제하는 API
@@ -114,7 +115,7 @@ public class ExperienceService {
             return new RestApiException(ErrorType.NOT_FOUND_EXPERIENCE);
         });
         experienceRepository.delete(experience);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 삭제완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "경험 삭제완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 유저가 자신의 페이지에서 자신의 경험리스트들을 확인가능한 API
@@ -133,7 +134,7 @@ public class ExperienceService {
             ExperienceDto experienceDto = ExperienceDto.of(experience);
             experienceList.add(experienceDto);
         }
-        return ResponseUtils.ok(experienceList, null);
+        return ResponseUtils.ok(experienceList, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 유저가 경험 리스트들중 하나를 클릭하면 자신의 세부적인 경험을 확인할 수 있는 API
@@ -147,7 +148,7 @@ public class ExperienceService {
         });
         ExperienceDto experienceDto = ExperienceDto.of(experience);
 
-        return ResponseUtils.ok(experienceDto, null);
+        return ResponseUtils.ok(experienceDto, ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 }

--- a/src/main/java/com/PuzzleU/Server/friendship/service/FriendshipService.java
+++ b/src/main/java/com/PuzzleU/Server/friendship/service/FriendshipService.java
@@ -50,7 +50,7 @@ public class FriendshipService {
             friendshipRepository.save(friendShip);
             };
             notificationService.sendFriend(user2, user1, "새로운 친구 요청이 있습니다!", NotificationType.FriendRequest);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
         }
 
 
@@ -71,7 +71,7 @@ public class FriendshipService {
         friendShip.setUserStatus(true);
         friendshipRepository.save(friendShip);
         notificationService.sendFriend(user2, user1, "친구가 되었습니다", NotificationType.FriendFinish);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구수락이 완료되었습니다"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구수락이 완료되었습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
     @Transactional
@@ -83,7 +83,7 @@ public class FriendshipService {
         Optional<FriendShip> friendShip_check = friendshipRepository.findByUser1AndUser2(user1, user2);
         FriendShip friendShip = friendShip_check.orElseThrow(()-> new RestApiException(ErrorType.NOT_FOUND_FRIENDSHIP));
         friendshipRepository.delete(friendShip);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "친구신청이 완료되었습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 }

--- a/src/main/java/com/PuzzleU/Server/heart/Service/HeartService.java
+++ b/src/main/java/com/PuzzleU/Server/heart/Service/HeartService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.heart.Service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.ErrorType;
@@ -55,7 +56,7 @@ public class HeartService {
         }
         competition.setCompetitionLike(heart);
         competitionRepository.save(competition);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 눌렀습니다"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 눌렀습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     @Transactional
     public ApiResponseDto<SuccessResponse> heartDelete(UserDetails loginuser, Long competitionId)
@@ -73,7 +74,7 @@ public class HeartService {
         heartRepository.delete(user_heart);
         competition.setCompetitionLike(heart);
         competitionRepository.save(competition);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 취소하였습니다"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "좋아요를 취소하였습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
 }

--- a/src/main/java/com/PuzzleU/Server/major/service/MajorService.java
+++ b/src/main/java/com/PuzzleU/Server/major/service/MajorService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.major.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.enumSet.ErrorType;
 import com.PuzzleU.Server.common.exception.RestApiException;
@@ -69,6 +70,6 @@ public class MajorService {
         MajorSearchTotalDto majorSearchTotalDto = MajorSearchTotalDto.builder()
                 .MajorList(majorSearchDtoList).build();
 
-        return ResponseUtils.ok(majorSearchTotalDto, null);
+        return ResponseUtils.ok(majorSearchTotalDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 }

--- a/src/main/java/com/PuzzleU/Server/notification/service/NotificationService.java
+++ b/src/main/java/com/PuzzleU/Server/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.notification.service;
 
 import com.PuzzleU.Server.apply.entity.Apply;
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.ErrorType;
@@ -210,7 +211,7 @@ public class NotificationService {
                 .filter(notification -> !notification.isRead())
                 .count();
         // 아직 안읽은 놈들의 개수를 보여준다
-        return ResponseUtils.ok(NotificationResponses.of(responses, unreadCount),null);
+        return ResponseUtils.ok(NotificationResponses.of(responses, unreadCount), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @Transactional
@@ -220,6 +221,6 @@ public class NotificationService {
                 .orElseThrow(()-> new EntityNotFoundException("존재하지 않는 알림"));
         notification.read();
         notificationRepository.save(notification);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"모든 알람을 읽었습니다"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"모든 알람을 읽었습니다"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 }

--- a/src/main/java/com/PuzzleU/Server/skillset/service/SkillsetService.java
+++ b/src/main/java/com/PuzzleU/Server/skillset/service/SkillsetService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.skillset.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.relations.dto.UserSkillsetRelationDto;
@@ -61,7 +62,7 @@ public class SkillsetService {
             userSkillsetRelationList.add(userSkillsetRelation);
         }
         userSkillsetRelationRepository.saveAll(userSkillsetRelationList);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 저장완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 저장완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
     @Transactional
@@ -78,7 +79,7 @@ public class SkillsetService {
             return new RestApiException(ErrorType.NOT_FOUND_USERSKILLSETRELATION);
         });
         userSkillsetRelationRepository.delete(userSkillsetrelation);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 삭제완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저스킬셋 삭제완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
     // 유저가 자신이 등록한 스킬셋의 리스트를 확인가능한 API
@@ -99,7 +100,7 @@ public class SkillsetService {
             userSkillsetRelationListDtos.add(userSkillsetRelationListDto);
         }
 
-        return ResponseUtils.ok(userSkillsetRelationListDtos, null);
+        return ResponseUtils.ok(userSkillsetRelationListDtos, ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 }

--- a/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
+++ b/src/main/java/com/PuzzleU/Server/team/service/TeamService.java
@@ -143,7 +143,7 @@ public class TeamService {
 
             notificationService.sendTeamJoin(user, loginuser, "새로운 팀에 참여되었습니다", NotificationType.TeamJoin, team, competition);
         }
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 생성완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 생성완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 구인글 수정
@@ -230,7 +230,7 @@ public class TeamService {
                 teamPositionRelationRepository.save(teamPositionRelation);
             }
 
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 수정완료"), null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 수정완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
         } else {
             return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, "유저의 권한이 없습니다."));
         }
@@ -264,7 +264,7 @@ public class TeamService {
             return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_FOUND, "유저가 속한 팀이 아닙니다."));
         }
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 삭제완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 구인글 삭제완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 
@@ -291,7 +291,7 @@ public class TeamService {
         competitionSearchTotalDto.setPageSize(pageSize);
         competitionSearchTotalDto.setPageNo(pageNo);
 
-        return ResponseUtils.ok(competitionSearchTotalDto, null);
+        return ResponseUtils.ok(competitionSearchTotalDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
 
@@ -337,7 +337,7 @@ public class TeamService {
         friendShipSearchResponseDto.setTotalPages(friendShips.getTotalPages());
         friendShipSearchResponseDto.setPageNo(pageNo);
         friendShipSearchResponseDto.setTotalElements(friendShips.getTotalElements());
-        return ResponseUtils.ok(friendShipSearchResponseDto, null);
+        return ResponseUtils.ok(friendShipSearchResponseDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 내가 만든 팀에 대한 정보를 모두 가져온다
@@ -399,7 +399,7 @@ public class TeamService {
                 teamApplyDto.setTeamAbstractDtoEnd(teamAbstractDto1);
             }
         }
-        return ResponseUtils.ok(teamApplyDto, null);
+        return ResponseUtils.ok(teamApplyDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @Transactional
@@ -461,7 +461,7 @@ public class TeamService {
         teamListDto.setPageNo(pageNo);
         teamListDto.setPageSize(pageSize);
 
-        return ResponseUtils.ok(teamListDto, null);
+        return ResponseUtils.ok(teamListDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 팀의 상태(진행/완료)를 수정한다
@@ -481,7 +481,7 @@ public class TeamService {
         if (teamUserRelation.getIsWriter() == true) {
             team.setTeamStatus(teamStatusDto.getTeamStatus());
             teamRepository.save(team);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 공고글 상태 변경완료"), null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "팀 공고글 상태 변경완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
         } else {
             return ResponseUtils.error(ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, "권한이 없습니다"));
         }
@@ -575,7 +575,7 @@ public class TeamService {
         teamApplyListDto.setTeam(simpleTeamDto);
         teamApplyListDto.setApplyList(userApplyDtoList);
 
-        return ResponseUtils.ok(teamApplyListDto, null);
+        return ResponseUtils.ok(teamApplyListDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 대기중인 지원자 수락/거절
@@ -606,13 +606,13 @@ public class TeamService {
             apply.setApplyStatus(ApplyStatus.ACCEPTED);
             applyRepository.save(apply);
             notificationService.sendApplyStatusJoin(applier, user, "지원 상태가 변경되었습니다", NotificationType.ApplyChange,apply);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 수락 완료"), null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 수락 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
         }
         else if (acceptOrRejectDto.getAcceptOrReject().equals("REJECT")) {
             apply.setApplyStatus(ApplyStatus.REJECTED);
             applyRepository.save(apply);
             notificationService.sendApplyStatusJoin(applier, user, "지원 상태가 변경되었습니다", NotificationType.ApplyChange,apply);
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 거절 완료"), null);
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "지원서 거절 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
         }
         else {
             throw new RestApiException(ErrorType.NOT_MATCH_ACCEPT_REJECT);
@@ -676,7 +676,7 @@ public class TeamService {
             teamListDto.setPageNo(pageNo);
             teamListDto.setPageSize(pageSize);
 
-            return ResponseUtils.ok(teamListDto, null);
+            return ResponseUtils.ok(teamListDto, ErrorResponse.builder().status(200).message("요청 성공").build());
         } catch (RestApiException e) {
             // 이미 정의된 예외인 경우 그대로 던집니다.
             throw e;
@@ -750,7 +750,7 @@ public class TeamService {
             }
             teamSpecificDto.setMembers(userSimpleDtoList);
 
-            return ResponseUtils.ok(teamSpecificDto, null);
+            return ResponseUtils.ok(teamSpecificDto, ErrorResponse.builder().status(200).message("요청 성공").build());
         } catch (RestApiException e) {
             throw e; // 이미 정의된 예외인 경우 그대로 던집니다.
         } catch (Exception e) {
@@ -812,6 +812,6 @@ public class TeamService {
         teamListDto.setPageNo(pageNo);
         teamListDto.setPageSize(pageSize);
 
-        return ResponseUtils.ok(teamListDto, null);
+        return ResponseUtils.ok(teamListDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 }

--- a/src/main/java/com/PuzzleU/Server/university/service/UniversityService.java
+++ b/src/main/java/com/PuzzleU/Server/university/service/UniversityService.java
@@ -1,6 +1,7 @@
 package com.PuzzleU.Server.university.service;
 
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.UniversityType;
@@ -77,7 +78,7 @@ public class UniversityService {
         userUniversityRelationRepository.save(userUniversityRelation);
 
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저학력 저장완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "유저학력 저장완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 
@@ -114,7 +115,7 @@ public class UniversityService {
                 .totalPages(universityPage.getTotalPages())
                 .last(universityPage.isLast()).build();
 
-        return ResponseUtils.ok(universitySearchTotalDto, null);
+        return ResponseUtils.ok(universitySearchTotalDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @Transactional
@@ -129,7 +130,7 @@ public class UniversityService {
             UniversityListDto universityListDto = getUniversityListDto(userUniversityRelation);
             universityListDtos.add(universityListDto);
         }
-        return ResponseUtils.ok(universityListDtos, null);
+        return ResponseUtils.ok(universityListDtos, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     private static UniversityListDto getUniversityListDto(UserUniversityRelation userUniversityRelation) {

--- a/src/main/java/com/PuzzleU/Server/user/service/UserService.java
+++ b/src/main/java/com/PuzzleU/Server/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.PuzzleU.Server.user.service;
 
 import com.PuzzleU.Server.apply.repository.ApplyRepository;
 import com.PuzzleU.Server.common.api.ApiResponseDto;
+import com.PuzzleU.Server.common.api.ErrorResponse;
 import com.PuzzleU.Server.common.api.ResponseUtils;
 import com.PuzzleU.Server.common.api.SuccessResponse;
 import com.PuzzleU.Server.common.enumSet.*;
@@ -107,18 +108,18 @@ public class UserService {
 
         // 입력한 username, password, admin 으로 user 객체 만들어 repository 에 저장
         UserRoleEnum role = requestDto.getAdmin() ? UserRoleEnum.ADMIN : UserRoleEnum.USER;
-        User user = User.of(LoginType.KAKAO, username, password, role);
+        User user = User.of(LoginType.NONE, username, password, role);
         userRepository.saveAndFlush(user); // 카카오로 임의 설정
 
         TokenDto tokenDto = new TokenDto();
         String accessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole());
         String refreshToken = jwtUtil.createRefreshToken(user.getUsername(), user.getRole());
 
-        tokenDto.setMessage("카카오 로그인 성공");
+        tokenDto.setMessage("회원가입 성공");
         tokenDto.setAccessToken(accessToken);
         tokenDto.setRefreshToken(refreshToken);
 
-        return ResponseUtils.ok(tokenDto,null);
+        return ResponseUtils.ok(tokenDto,ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @org.springframework.transaction.annotation.Transactional(readOnly = true)
@@ -136,7 +137,7 @@ public class UserService {
         response.setHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.get().getUsername(), user.get().getRole()));
         String jwtToken = jwtUtil.createToken(user.get().getUsername(), user.get().getRole());
         jwtToken.substring(7);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "로그인 성공"), jwtToken);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "로그인 성공"), ErrorResponse.builder().build());
 
     }
 
@@ -229,7 +230,7 @@ public class UserService {
         userSkillsetRelationRepository.saveAll(userSkillsetRelations);
         experienceRepository.saveAll(experiences);
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "선택사항 저장완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "선택사항 저장완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @org.springframework.transaction.annotation.Transactional
@@ -324,7 +325,7 @@ public class UserService {
             }
         }
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 필수 정보 저장 완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "회원가입 필수 정보 저장 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 회원가입 시 퍼즐 ID 중복 여부 반환
@@ -335,7 +336,7 @@ public class UserService {
             throw new RestApiException(ErrorType.DUPLICATED_PUZZLE_ID);
         }
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "사용할 수 있는 퍼즐 ID입니다."), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "사용할 수 있는 퍼즐 ID입니다."), ErrorResponse.builder().status(200).message("요청 성공").build());
 
     }
 
@@ -362,7 +363,7 @@ public class UserService {
         friendShipSearchResponseDto.setPageNo(pageNo);
         friendShipSearchResponseDto.setPageSize(pageSize);
         friendShipSearchResponseDto.setTotalElements(users.getTotalElements());
-        return ResponseUtils.ok(friendShipSearchResponseDto, null);
+        return ResponseUtils.ok(friendShipSearchResponseDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @Transactional
@@ -408,7 +409,7 @@ public class UserService {
         }
 
         userRepository.save(user);
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "프로필 기본 정보 수정 완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "프로필 기본 정보 수정 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
 
@@ -517,7 +518,7 @@ public class UserService {
         userMyProfileDto.setExperienceList(userProfileExperienceDtoList);
         userMyProfileDto.setSkillsetList(userProfileSkillsetDtoList);
 
-        return ResponseUtils.ok(userMyProfileDto, null);
+        return ResponseUtils.ok(userMyProfileDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
     public ApiResponseDto<List<UserSimpleDto>> userSearch(UserDetails loginUser, int pageNo, int pageSize, String sortBy, String search) {
         User loginuser = userRepository.findByUsername(loginUser.getUsername())
@@ -537,7 +538,7 @@ public class UserService {
                 })
                 .collect(Collectors.toList());
 
-        return ResponseUtils.<List<UserSimpleDto>>ok(userSimpleDtoList, null);
+        return ResponseUtils.<List<UserSimpleDto>>ok(userSimpleDtoList, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     @Transactional
@@ -674,7 +675,7 @@ public class UserService {
         userProfileDto.setExperienceList(userProfileExperienceDtoList);
         userProfileDto.setSkillsetList(userProfileSkillsetDtoList);
 
-        return ResponseUtils.ok(userProfileDto, null);
+        return ResponseUtils.ok(userProfileDto, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     // 정보 수신 여부 동의 수정
@@ -695,7 +696,7 @@ public class UserService {
 
         userRepository.save(user);
 
-        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "정보 수신 여부 저장 완료"), null);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "정보 수신 여부 저장 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     public ApiResponseDto<List<TermDto>> getTermsConsent() {
@@ -732,7 +733,7 @@ public class UserService {
                 .termContent(Term.RECEIVE_MARKETING_TERM.getTermContent()).build();
         termDtoList.add(term5);
 
-        return ResponseUtils.ok(termDtoList, null);
+        return ResponseUtils.ok(termDtoList, ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     public User getUserFromAuth()


### PR DESCRIPTION
- jwt를 삭제하고 성공시에도 `error` value 부분에 status와 message부분이 고정적으로 뜨도록 만들었습니다

변경된 형식 ex)
{
    "success": true,
    "response": {
        "competitionList": [
            {
                "competitionId": 18,
                "competitionName": "문화 유산 재난 안전 공모전",
                "competitionTypeList": [
                    "PLAN",
                    "LITURE"
                ],
                "createdAt": "2024-03-08 10:12",
                "competitionHeart": 0,
                "competitionPoster": "https://puzzleu-bucket.s3.ap-northeast-2.amazonaws.com/competition/문화유산재난안전공모전.png",
                "competitionMatching": 0,
                "competitionVisit": 0,
                "competitionDday": -17
            },
        ],
        "pageNo": 0,
        "pageSize": 6,
        "totalElements": 19,
        "totalPages": 4,
        "last": false
    },
    "error": {
        "status": 200,
        "message": "성공"
    }
}